### PR TITLE
Minor Bug fixes: loading FES currents and nodal_modulation documentation

### DIFF
--- a/pyTMD/arguments.py
+++ b/pyTMD/arguments.py
@@ -541,10 +541,10 @@ def nodal_modulation(
 
     Returns
     -------
-    f: np.ndarray
-        nodal modulation factor
     u: np.ndarray
         nodal correction angle (radians)
+    f: np.ndarray
+        nodal modulation factor
     """
     # set default keyword arguments
     kwargs.setdefault('corrections', 'OTIS')

--- a/pyTMD/io/model.py
+++ b/pyTMD/io/model.py
@@ -1090,7 +1090,7 @@ class model:
                 model_file = self.model_file
             # extract tidal constants for model type
             amp,ph = FES.extract_constants(lon, lat,
-                self.model_file, version=self.version,
+                model_file, version=self.version,
                 compressed=self.compressed, **kwargs)
             # available model constituents
             c = self.constituents


### PR DESCRIPTION
Hi @tsutterley,

Thanks for the great library!

I have been looking into using pyTMD for setting up boundary conditions for hydrodynamic models.

In the process I picked up a couple of minor bugs:

1. The in io,model for format in ('FES-ascii', 'FES-netcdf') it was incorrectly passing self.model_file rather than the dictionary entry for the type ('u','v')
2. The pydoc for nodal_modulation had the return values in the wrong order.

HTH.