### PR TITLE
feat: add `query` and `path` functions to `URL` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,12 @@
 *.7z
 *.dmg
 *.gz
+*.h5
+*.hdf
 *.iso
 *.jar
 *.mat
+*.nc
 *.rar
 *.tar
 *.zip

--- a/doc/source/api_reference/utilities.rst
+++ b/doc/source/api_reference/utilities.rst
@@ -2,7 +2,7 @@
 utilities
 =========
 
-Download and management utilities for syncing time and auxiliary files
+Download and management utilities for syncing files
 
 `Source code`__
 

--- a/doc/source/background/Ocean-Load-Tides.rst
+++ b/doc/source/background/Ocean-Load-Tides.rst
@@ -72,7 +72,7 @@ Prediction
 
 ``pyTMD.io`` contains routines for reading major constituent values from commonly available tide models, and interpolating those values to spatial locations.
 ``pyTMD`` uses the astronomical argument formalism outlined in :cite:t:`Doodson:1921kt` for the prediction of ocean and load tides. 
-For any given time, :func:`pyTMD.astro.mean_longitudes` calculates the longitudes of the moon (:math:`S`), sun (:math:`H`), lunar perigee (:math:`P`), ascending lunar node (:math:`N`) and solar perigee (:math:`Ps`), which are used in combination with the lunar hour angle (:math:`\tau`) and the extended Doodson number (:math:`k`) in a seven-dimensional Fourier series :cite:p:`Doodson:1921kt,Dietrich:1980ua,Pugh:2014di`.
+For any given time, :py:func:`pyTMD.astro.mean_longitudes` calculates the longitudes of the moon (:math:`S`), sun (:math:`H`), lunar perigee (:math:`P`), ascending lunar node (:math:`N`) and solar perigee (:math:`Ps`), which are used in combination with the lunar hour angle (:math:`\tau`) and the extended Doodson number (:math:`k`) in a seven-dimensional Fourier series :cite:p:`Doodson:1921kt,Dietrich:1980ua,Pugh:2014di`.
 Each constituent has a particular "Doodson number" describing the polynomial coefficients of each of these astronomical terms in the Fourier series :cite:p:`Doodson:1921kt`. 
 These can be summed together to estimate the equilibrium phase (:math:`G`).
 
@@ -87,5 +87,5 @@ These can be summed together to estimate the equilibrium phase (:math:`G`).
     ``pyTMD`` stores these coefficients in a `JSON database <https://github.com/pyTMD/pyTMD/blob/main/pyTMD/data/doodson.json>`_ supplied with the program.
 
 Together the Doodson coefficients and additional nodal corrections (:math:`f` and :math:`u`) are used by ``pyTMD`` to calculate the frequencies and 18.6-year modulations of the tidal constituents, and enable the accurate determination of tidal values :cite:p:`Schureman:1958ty,Dietrich:1980ua`.
-After the determination of the major constituents, :func:`pyTMD.predict.infer_minor` can estimate the amplitudes of minor constituents using inference methods :cite:p:`Schureman:1958ty,Ray:2017jx`.
+After the determination of the major constituents, :py:func:`pyTMD.predict.infer_minor` can estimate the amplitudes of minor constituents using inference methods :cite:p:`Schureman:1958ty,Ray:2017jx`.
 

--- a/doc/source/background/Pole-Tides.rst
+++ b/doc/source/background/Pole-Tides.rst
@@ -10,7 +10,7 @@ Methods
 -------
 
 The formalism for estimating the pole tides within ``pyTMD`` is also based upon `IERS Conventions <https://iers-conventions.obspm.fr/>`_.
-For ocean pole tides, :func:`pyTMD.predict.ocean_pole_tide` uses the equilibrium response model from :cite:t:`Desai:2002ev` as recommended by IERS Conventions :cite:p:`Petit:2010tp`.
+For ocean pole tides, :py:func:`pyTMD.predict.ocean_pole_tide` uses the equilibrium response model from :cite:t:`Desai:2002ev` as recommended by IERS Conventions :cite:p:`Petit:2010tp`.
 ``pyTMD`` uses the ``timescale`` library for reading the Earth Orientation Parameters (EOPs) necessary for computing load pole and ocean pole tide variations.
 The currently accepted formalism for estimating the reference position of the Earth's figure axis at a given date is the `IERS 2018 secular pole model <https://iers-conventions.obspm.fr/chapter7.php>`_:
 

--- a/doc/source/background/Solid-Earth-Tides.rst
+++ b/doc/source/background/Solid-Earth-Tides.rst
@@ -10,8 +10,8 @@ Methods
 -------
 
 Within ``pyTMD``, the tidal deformation of the Earth can be modeled using two methods:
-1) :func:`pyTMD.predict.solid_earth_tide` uses :term:`Ephemerides` and the formalism described in the `IERS Conventions <https://iers-conventions.obspm.fr/>`_, which are based on :cite:t:`Wahr:1981ea` and :cite:t:`Mathews:1997js`, or
-2) :func:`pyTMD.predict.body_tide` uses tide potential catalogs :cite:p:`Wenzel:1997kn` and the spherical harmonic formalism described in :cite:t:`Cartwright:1971iz`.
+1) :py:func:`pyTMD.predict.solid_earth_tide` uses :term:`Ephemerides` and the formalism described in the `IERS Conventions <https://iers-conventions.obspm.fr/>`_, which are based on :cite:t:`Wahr:1981ea` and :cite:t:`Mathews:1997js`, or
+2) :py:func:`pyTMD.predict.body_tide` uses tide potential catalogs :cite:p:`Wenzel:1997kn` and the spherical harmonic formalism described in :cite:t:`Cartwright:1971iz`.
 For the ephemerides method, analytical approximate positions for the sun and moon can be calculated, or high-resolution numerical ephemerides for the sun and moon can be downloaded from the `Jet Propulsion Laboratory <https://ssd.jpl.nasa.gov/planets/orbits.html>`_.
 These astronomical positions are used to estimate the instantaneous tide potential impacting the solid Earth :cite:p:`Merriam:1992kg`.
 For the catalog method, some tide potential catalogs additionally include the potentials induced by the motions of the closest planetary bodies [see :ref:`tab-catalogs`] and higher degree harmonics [see :ref:`fig-sphharm`].

--- a/doc/source/getting_started/AVISO-Registration.rst
+++ b/doc/source/getting_started/AVISO-Registration.rst
@@ -17,4 +17,4 @@ Registering for an account is free, and provides access to a variety of oceanogr
 3. You will receive two emails: one confirming your registration, and another with your login details. Your username is typically your email address.
 4. This gains you access to the `My AVISO+ data portal <https://www.aviso.altimetry.fr/en/my-aviso-plus.html>`_ and FTP servers.
 
-After registering, you can use :func:`pyTMD.datasets.fetch_aviso_fes` to download the FES tide models.
+After registering, you can use :py:func:`pyTMD.datasets.fetch_aviso_fes` to download the FES tide models.

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -33,9 +33,9 @@ Data Access
 ###########
 
 Some tide models can be programmatically downloaded using the fetching routines in ``pyTMD.datasets``.
-OTIS-formatted Arctic Ocean models can be downloaded from the NSF ArcticData server using the :func:`pyTMD.datasets.fetch_arcticdata` function.
-GOT models can be downloaded from the NASA GSFC server using the :func:`pyTMD.datasets.fetch_gsfc_got` function.
-Users registered with AVISO [see :ref:`aviso-registration`] can download FES models from their FTP server using the :func:`pyTMD.datasets.fetch_aviso_fes` function.
+OTIS-formatted Arctic Ocean models can be downloaded from the NSF ArcticData server using the :py:func:`pyTMD.datasets.fetch_arcticdata` function.
+GOT models can be downloaded from the NASA GSFC server using the :py:func:`pyTMD.datasets.fetch_gsfc_got` function.
+Users registered with AVISO [see :ref:`aviso-registration`] can download FES models from their FTP server using the :py:func:`pyTMD.datasets.fetch_aviso_fes` function.
 
 Other tide models may require manual downloading due to licensing agreements or limitations on programmatic access.
 TPXO models (OTIS and ATLAS formats) can be requested from the data producers after `registration <https://www.tpxo.net/tpxo-products-and-registration>`_.
@@ -216,7 +216,7 @@ Interpolation
 #############
 
 For converting from model coordinates, ``pyTMD`` uses the ``linear`` and ``nearest`` spatial interpolation routines from ``xarray``.
-For coastal or near-grounded points, the model can be extrapolated with :func:`pyTMD.interpolate.extrapolate` using a nearest-neighbor routine.
+For coastal or near-grounded points, the model can be extrapolated with :py:func:`pyTMD.interpolate.extrapolate` using a nearest-neighbor routine.
 The default maximum extrapolation distance is 10 kilometers.
 This default distance may not be a large enough extrapolation for some applications and models.
 

--- a/doc/source/project/Testing.rst
+++ b/doc/source/project/Testing.rst
@@ -12,7 +12,7 @@ Running the test suite requires a `dev installation <../getting_started/Install.
 Test Data Access
 ^^^^^^^^^^^^^^^^
 The test suite requires access to some tide model data files [see `Data Access <../getting_started/Getting-Started.html#data-access>`_].
-For project developers, the data files can be fetched from a permanent open research repository (``figshare`` or ``zenodo``) using the :func:`pyTMD.datasets.fetch_test_data` function.
+For project developers, the data files can be fetched from a permanent open research repository (``figshare`` or ``zenodo``) using the :py:func:`pyTMD.datasets.fetch_test_data` function.
 These files accessed similarly during `continuous integration (CI) testing <./Testing.html#continuous-integration>`_.
 
 Fetching the data using ``pixi``:

--- a/doc/source/release_notes/release-v2.2.9.rst
+++ b/doc/source/release_notes/release-v2.2.9.rst
@@ -41,7 +41,7 @@
 * ``docs``: add acknowledgment to our JOSS reviewers `(#474) <https://github.com/pyTMD/pyTMD/pull/474>`_
 * ``test``: fix ``pixi`` task for testing `(#475) <https://github.com/pyTMD/pyTMD/pull/475>`_
 * ``feat``: can solve with inferred minor constituents (post-fit) `(#476) <https://github.com/pyTMD/pyTMD/pull/476>`_
-* ``docs``: add ``:func:`` and ``:py:class:`` pointers `(#477) <https://github.com/pyTMD/pyTMD/pull/477>`_
+* ``docs``: add ``:py:func:`` and ``:py:class:`` pointers `(#477) <https://github.com/pyTMD/pyTMD/pull/477>`_
 * ``refactor``: remove some deprecated functions `(#477) <https://github.com/pyTMD/pyTMD/pull/477>`_
 * ``feat``: added option to use memory mapping for reading large files `(#478) <https://github.com/pyTMD/pyTMD/pull/478>`_
 * ``feat``: create ``fetch`` class to group fetching functions `(#479) <https://github.com/pyTMD/pyTMD/pull/479>`_

--- a/pyTMD/compute.py
+++ b/pyTMD/compute.py
@@ -221,11 +221,11 @@ def corrections(
         times. The exact return type, dimensions, and units are those of
         the underlying helper function:
 
-        * ``correction in {'ocean', 'load'}`` → :func:`tide_elevations`
-        * ``correction == 'LPET'`` → :func:`LPET_elevations`
-        * ``correction == 'LPT'`` → :func:`LPT_displacements`
-        * ``correction == 'OPT'`` → :func:`OPT_displacements`
-        * ``correction == 'SET'`` → :func:`SET_displacements`
+        * ``correction in {'ocean', 'load'}`` → :py:func:`tide_elevations`
+        * ``correction == 'LPET'`` → :py:func:`LPET_elevations`
+        * ``correction == 'LPT'`` → :py:func:`LPT_displacements`
+        * ``correction == 'OPT'`` → :py:func:`OPT_displacements`
+        * ``correction == 'SET'`` → :py:func:`SET_displacements`
 
         Refer to the respective helper function docstrings for details
         on the variable names, units, and metadata of the returned object.

--- a/pyTMD/constituents.py
+++ b/pyTMD/constituents.py
@@ -2407,7 +2407,7 @@ def _complex_love_numbers(omega: np.ndarray, **kwargs):
     omega: np.ndarray
         Angular frequency (radians per second)
     kwargs: dict
-        Keyword arguments for :func:`pyTMD.constituents._love_numbers`
+        Keyword arguments for :py:func:`pyTMD.constituents._love_numbers`
 
     Returns
     -------

--- a/pyTMD/io/dataset.py
+++ b/pyTMD/io/dataset.py
@@ -603,7 +603,7 @@ class Dataset:
         Parameters
         ----------
         bounds: list, tuple
-            Bounding box [min_x, max_x, min_y, max_y]
+            Bounding box ``[min_x, max_x, min_y, max_y]``
         buffer: int or float, default 0
             Buffer to add to bounds for cropping
         """
@@ -663,7 +663,7 @@ class Dataset:
         other: xarray.Dataset
             ``Dataset`` with missing values to be extrapolated
         kwargs: dict
-            Keyword arguments for :func:`pyTMD.interpolate._nearest_neighbors`
+            Keyword arguments for :py:func:`pyTMD.interpolate._nearest_neighbors`
 
         Returns
         -------
@@ -825,7 +825,7 @@ class Dataset:
         t: float or np.ndarray
             Days relative to 1992-01-01T00:00:00 UTC
         kwargs: dict
-            Keyword arguments for :func:`pyTMD.predict.infer_minor`
+            Keyword arguments for :py:func:`pyTMD.predict.infer_minor`
 
         Returns
         -------
@@ -846,7 +846,7 @@ class Dataset:
         Parameters
         ----------
         kwargs: dict
-            Keyword arguments for :func:`pyTMD.interpolate.inpaint`
+            Keyword arguments for :py:func:`pyTMD.interpolate.inpaint`
 
         Returns
         -------
@@ -987,7 +987,7 @@ class Dataset:
         t: float or np.ndarray
             Days relative to 1992-01-01T00:00:00 UTC
         kwargs: dict
-            Keyword arguments for :func:`pyTMD.predict.time_series`
+            Keyword arguments for :py:func:`pyTMD.predict.time_series`
 
         Returns
         -------

--- a/pyTMD/predict/ocean_load.py
+++ b/pyTMD/predict/ocean_load.py
@@ -142,7 +142,7 @@ def time_series(
     ds: xarray.Dataset
         Dataset containing tidal harmonic constants
     kwargs: dict
-        Keyword arguments for :func:`pyTMD.constituents.arguments`
+        Keyword arguments for :py:func:`pyTMD.constituents.arguments`
 
     Returns
     -------

--- a/pyTMD/utilities.py
+++ b/pyTMD/utilities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 utilities.py
-Written by Tyler Sutterley (01/2026)
+Written by Tyler Sutterley (04/2026)
 Download and management utilities for syncing time and auxiliary files
 
 PYTHON DEPENDENCIES:
@@ -11,6 +11,7 @@ PYTHON DEPENDENCIES:
         https://pypi.org/project/platformdirs/
 
 UPDATE HISTORY:
+    Updated 04/2026: add query and path functions to URL class
     Updated 01/2026: raise original exceptions in cases of HTTPError/URLError
     Updated 12/2025: add URL class to build and operate on URLs
         no longer subclassing pathlib.Path for working directories
@@ -363,6 +364,10 @@ class URL:
         """Ping URL to check connection"""
         return check_connection(self.urlname, *args, **kwargs)
 
+    def query(self, *args, **kwargs):
+        """List contents from URL"""
+        return http_list(self.urlname, headers=self._headers, *args, **kwargs)
+
     def read(self, *args, **kwargs):
         """Open URL and read response"""
         return self.urlopen(*args, **kwargs).read()
@@ -403,6 +408,11 @@ class URL:
         """URL parts as a tuple"""
         paths = url_split(self._components.path)
         return (self.scheme, self.netloc, *paths)
+
+    @property
+    def path(self):
+        """URL path"""
+        return self._components.path
 
     @property
     def scheme(self):

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -47,12 +47,12 @@ def download_nodes(N=324, cleanup=False):
 
 # Franke's 2D evaluation function
 def franke_2d(x,y):
-	F1 = 0.75*np.exp(-((9.0*x-2.0)**2 + (9.0*y-2.0)**2)/4.0)
-	F2 = 0.75*np.exp(-((9.0*x+1.0)**2/49.0-(9.0*y+1.0)/10.0))
-	F3 = 0.5*np.exp(-((9.0*x-7.0)**2 + (9.0*y-3.0)**2)/4.0)
-	F4 = 0.2*np.exp(-((9.0*x-4.0)**2 + (9.0*y-7.0)**2))
-	F = F1 + F2 + F3 - F4
-	return F
+    F1 = 0.75*np.exp(-((9.0*x-2.0)**2 + (9.0*y-2.0)**2)/4.0)
+    F2 = 0.75*np.exp(-((9.0*x+1.0)**2/49.0-(9.0*y+1.0)/10.0))
+    F3 = 0.5*np.exp(-((9.0*x-7.0)**2 + (9.0*y-3.0)**2)/4.0)
+    F4 = 0.2*np.exp(-((9.0*x-4.0)**2 + (9.0*y-7.0)**2))
+    F = F1 + F2 + F3 - F4
+    return F
 
 # Franke's 3D evaluation function
 def franke_3d(x,y,z):
@@ -200,7 +200,7 @@ def test_extrapolation_checks(N=324):
     # in case where there are no valid grid points
     test = pyTMD.interpolate.extrapolate(LON, LAT, FI, lon, lat,
         is_geographic=True)
-    assert(np.all(test.isnull()))
+    assert test.isnull().all()
     # use nearest neighbors extrapolation
     # in case where there are no points to be extrapolated
     test = pyTMD.interpolate.extrapolate(LON, LAT, FI, [], [])

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,8 +1,9 @@
 """
-test_model.py (11/2025)
+test_model.py (04/2026)
 Tests the reading of model definition files
 
 UPDATE HISTORY:
+    Updated 04/2026: added cleanup options to functional tests
     Updated 11/2025: use new z, u, v database and JSON format
     Updated 07/2025: added GOT4.10_SAL subset of constituents
     Updated 06/2025: added function to check extra databases
@@ -88,7 +89,7 @@ def test_definition_FES():
     assert parsed_constituents == constituents
 
 # PURPOSE: test glob file functionality
-def test_definition_FES_glob():
+def test_definition_FES_glob(cleanup=False):
     """Tests the reading of the FES2014 model definition file
     with glob file searching
     """
@@ -145,7 +146,8 @@ def test_definition_FES_glob():
     # close the glob definition file
     fid.close()
     # clean up model
-    shutil.rmtree(filepath.joinpath('fes2014'))
+    if cleanup:
+        shutil.rmtree(filepath.joinpath('fes2014'))
 
 def test_definition_FES_currents():
     """Tests the reading of the FES2014 model definition file for currents
@@ -244,7 +246,7 @@ def test_definition_FES_currents():
     assert m['v'].variable == 'meridional_tidal_current'
 
 # PURPOSE: test glob file functionality
-def test_definition_FES_currents_glob():
+def test_definition_FES_currents_glob(cleanup=False):
     """Tests the reading of the FES2014 model definition file
     with glob file searching for currents
     """
@@ -359,9 +361,10 @@ def test_definition_FES_currents_glob():
     # close the glob definition file
     fid.close()
     # clean up model
-    shutil.rmtree(filepath.joinpath('fes2014'))
+    if cleanup:
+        shutil.rmtree(filepath.joinpath('fes2014'))
 
-def test_definition_GOT():
+def test_definition_GOT(cleanup=False):
     """Tests the reading of the GOT4.10 model definition file
     """
     # read model definition file
@@ -471,7 +474,7 @@ def test_definition_TPXO9():
     assert m.compressed is False
 
 # PURPOSE: test glob file functionality
-def test_definition_TPXO9_glob():
+def test_definition_TPXO9_glob(cleanup=False):
     """Tests the reading of the TPXO9-atlas-v5 model definition file
     with glob file searching
     """
@@ -529,7 +532,8 @@ def test_definition_TPXO9_glob():
     # close the glob definition file
     fid.close()
     # clean up model
-    shutil.rmtree(filepath.joinpath('TPXO9_atlas_v5'))
+    if cleanup:
+        shutil.rmtree(filepath.joinpath('TPXO9_atlas_v5'))
 
 def test_definition_TPXO9_currents():
     """Tests the reading of the TPXO9-atlas-v5 model definition file
@@ -585,7 +589,7 @@ def test_definition_TPXO9_currents():
     assert m['v'].variable == 'meridional_tidal_current'
 
 # PURPOSE: test glob file functionality
-def test_definition_TPXO9_currents_glob():
+def test_definition_TPXO9_currents_glob(cleanup=False):
     """Tests the reading of the TPXO9-atlas-v5 model definition file for
     currents with glob file searching
     """
@@ -661,7 +665,8 @@ def test_definition_TPXO9_currents_glob():
     # close the glob definition file
     fid.close()
     # clean up model
-    shutil.rmtree(filepath.joinpath('TPXO9_atlas_v5'))
+    if cleanup:
+        shutil.rmtree(filepath.joinpath('TPXO9_atlas_v5'))
 
 # parameterize model
 @pytest.mark.parametrize("MODEL", pyTMD.io.model.FES())


### PR DESCRIPTION
test: added cleanup options to `model` tests
docs: use `:py:func:` instead of `:func:`
