### PR TITLE
docs: add section on `type` variable usage

### DIFF
--- a/doc/source/api_reference/predict/ocean_load.rst
+++ b/doc/source/api_reference/predict/ocean_load.rst
@@ -23,3 +23,5 @@ ocean_load
 .. autofunction:: pyTMD.predict._infer_long_period
 
 .. autofunction:: pyTMD.predict.equilibrium_tide
+
+.. autofunction:: pyTMD.predict.find_peaks

--- a/doc/source/background/Astronomy.rst
+++ b/doc/source/background/Astronomy.rst
@@ -125,7 +125,7 @@ where :math:`\bar\varepsilon` is the mean obliquity :cite:p:`Capitaine:2003fx,Ca
 These nutation angles (:math:`\Delta\psi` and :math:`\Delta\varepsilon`) and the mean obliquity (:math:`\bar\varepsilon`) are combined when forming the nutation rotation matrix (:math:`\mathbf{N}`) used in the transformation from :ref:`celestial <celestial-reference>` to terrestrial reference frames [see :ref:`Equation 6.5 <eq:6.5>`] :cite:p:`Kaplan:1989cf,Petit:2010tp`.
 
 The difference between Greenwich Apparent Sidereal Time (GAST) and Greenwich Mean Sidereal Time (GMST) defines the "equation of the equinoxes", which is calculated using the :term:`nutation <Nutation>` terms along with higher-order complementary terms [see :ref:`sidereal-time`] :cite:p:`Capitaine:2003fx,Capitaine:2003fw,Petit:2010tp`.
-:func:`pyTMD.astro.itrs` calculates GAST when forming the ITRS rotation matrix for converting a :ref:`celestial reference frame <celestial-reference>` to an Earth-centered Earth-fixed (ECEF) reference frame [see :ref:`ephemerides`] :cite:p:`Petit:2010tp`.
+:py:func:`pyTMD.astro.itrs` calculates GAST when forming the ITRS rotation matrix for converting a :ref:`celestial reference frame <celestial-reference>` to an Earth-centered Earth-fixed (ECEF) reference frame [see :ref:`ephemerides`] :cite:p:`Petit:2010tp`.
 
 .. plot:: ./background/obliquity-ecliptic.py
     :caption: Ecliptical Plane and Vernal Equinox in the Celestial Sphere
@@ -141,10 +141,10 @@ Ephemerides are tables or mathematical representations giving the positions of a
 ``pyTMD`` can calculate these positions using either high-precision numerical `ephemerides from JPL <https://ssd.jpl.nasa.gov/planets/orbits.html>`_  or one of several analytical approximations.
 The JPL ephemerides are numerically integrated solutions to the equations of motion for the planets, sun and moon and are provided in the form of binary "kernels".
 They are computed from a comprehensive set of observations including spacecraft radio range data, lunar laser range data, and Very Long Baseline Interferometry (VLBI) measurements :cite:p:`Folkner:2014un,Park:2021fa`.
-``pyTMD`` uses the ``jplephem`` package to read the JPL ephemeris kernels using :func:`pyTMD.astro.solar_ephemerides` and :func:`pyTMD.astro.lunar_ephemerides`.
+``pyTMD`` uses the ``jplephem`` package to read the JPL ephemeris kernels using :py:func:`pyTMD.astro.solar_ephemerides` and :py:func:`pyTMD.astro.lunar_ephemerides`.
 The data is provided in the :ref:`celestial reference frame <celestial-reference>`, which ``pyTMD`` transforms to get locations in reference to the Earth.
 
-``pyTMD`` can also use analytical approximations to compute the solar and lunar positions using :func:`pyTMD.astro.solar_approximate` and :func:`pyTMD.astro.lunar_approximate`.
+``pyTMD`` can also use analytical approximations to compute the solar and lunar positions using :py:func:`pyTMD.astro.solar_approximate` and :py:func:`pyTMD.astro.lunar_approximate`.
 These express the solar and lunar coordinates as a truncated trigonometric or polynomial series :cite:p:`Meeus:1991vh`.
 They are less accurate than using ephemerides, but are faster to compute and do not require downloading the kernel files.
 

--- a/doc/source/background/Harmonic-Analysis.rst
+++ b/doc/source/background/Harmonic-Analysis.rst
@@ -76,7 +76,7 @@ Note that the sine terms are negative in the design matrix, which follows the co
     \hat{A}_k &= \sqrt{\hat{c}_k^2 + \hat{s}_k^2} \\
     \hat{\theta}_k &= \mathrm{arctan2}(-\hat{s}_k, \hat{c}_k)
 
-``pyTMD`` includes several solver options in order to handle rank-deficient systems or include bounds on the solution variables.
+:py:func:`pyTMD.solve.constants` includes several solver options in order to handle rank-deficient systems or include bounds on the solution variables.
 
 .. list-table:: Solver Methods
     :header-rows: 1
@@ -116,6 +116,6 @@ Assuming that the :term:`tidal admittance <Admittance>` varies smoothly with fre
 This can be the case when the record of observations is too short to independently resolve constituents that are close in frequency :cite:p:`Foreman:2009bg`.
 Including inference as part of the fitting process can avoid contaminating the regression of major constituents, and can improve their overall estimation :cite:p:`Foreman:1989dt,Foreman:2009bg`.
 
-In ``pyTMD``, this inference is performed *after* the primary regression using a bootstrap iteration procedure.
+In :py:func:`pyTMD.solve.constants`, this inference is performed *after* the primary regression using a bootstrap iteration procedure.
 After each fit, the time series of the inferred minor constituents is reconstructed and then removed from the observation time series.
 The process is repeated and the observation vector :math:`\mathbf{h}` is continually modified until the specified number of iterations has been reached.

--- a/doc/source/background/Ocean-Load-Tides.rst
+++ b/doc/source/background/Ocean-Load-Tides.rst
@@ -73,7 +73,7 @@ Prediction
 ----------
 
 ``pyTMD.io`` contains routines for reading major constituent values from commonly available tide models, and interpolating those values to spatial locations.
-``pyTMD`` uses the astronomical argument formalism outlined in :cite:t:`Doodson:1921kt` for the prediction of ocean and load tides. 
+:py:func:`pyTMD.constituents.arguments` uses the astronomical argument formalism outlined in :cite:t:`Doodson:1921kt` for the prediction of ocean and load tides. 
 For any given time, :py:func:`pyTMD.astro.mean_longitudes` calculates the longitudes of the moon (:math:`S`), sun (:math:`H`), lunar perigee (:math:`P`), ascending lunar node (:math:`N`) and solar perigee (:math:`Ps`), which are used in combination with the lunar hour angle (:math:`\tau`) and the extended Doodson number (:math:`k`) in a seven-dimensional Fourier series :cite:p:`Doodson:1921kt,Dietrich:1980ua,Pugh:2014di`.
 Each constituent has a particular "Doodson number" describing the polynomial coefficients of each of these astronomical terms in the Fourier series :cite:p:`Doodson:1921kt`. 
 These can be summed together to estimate the equilibrium phase (:math:`G`).
@@ -91,3 +91,16 @@ These can be summed together to estimate the equilibrium phase (:math:`G`).
 Together the Doodson coefficients and additional nodal corrections (:math:`f` and :math:`u`) are used by ``pyTMD`` to calculate the frequencies and 18.6-year modulations of the tidal constituents, and enable the accurate determination of tidal values :cite:p:`Schureman:1958ty,Dietrich:1980ua`.
 After the determination of the major constituents, :py:func:`pyTMD.predict.infer_minor` can estimate the amplitudes of minor constituents using inference methods :cite:p:`Schureman:1958ty,Ray:2017jx`.
 
+High and Low Water
+------------------
+
+Tide tables list the times and heights of successive :term:`high <High Water Height>` and :term:`low <Low Water Height>` water points at a location, and are a practical summary of tidal predictions.
+The high and low waters correspond to maxima and minima of the tidal time series :math:`h(t)` [:ref:`Equation 1.1 <eq:1.1>`].
+:py:func:`pyTMD.predict.find_peaks` detects the location of these peaks (and troughs) by numerically differentiating the time series :math:`\partial h / \partial t` and then identifying zero crossings of first derivative.
+Zero crossings with a negative gradient correspond to high water (maxima) and those with a positive gradient correspond to low water (minima).
+Note that the accuracies of these detected extrema are directly dependent on the temporal resolution of the prediction data.
+
+.. important::
+    
+    ``pyTMD`` uses times in UTC for all calculations [see :ref:`Time Standards <time-standards>`].
+    Creating a tide table in *local time* requires applying the appropriate time zone and daylight savings time conversions.

--- a/doc/source/background/Spherical-Harmonics.rst
+++ b/doc/source/background/Spherical-Harmonics.rst
@@ -24,7 +24,8 @@ Spherical harmonics of degree :math:`l` and order :math:`m` are defined as:
     Y_l^m(\theta, \lambda) = N_l^m\, P_l^m(\cos\theta)\, e^{im\lambda} 
 
 where :math:`P_l^m(x)` are the associated Legendre polynomials and :math:`N_l^m` is a normalization factor :cite:p:`HofmannWellenhof:2006hy,Munk:1960uk`.
-The associated Legendre polynomials of degree :math:`l` and order :math:`m` are calculated in ``pyTMD`` using the explicit formula (1-67) from :cite:t:`HofmannWellenhof:2006hy`:
+:py:func:`pyTMD.math.sph_harm` calculates spherical harmonics using the normalization factor from Equation A5 in :cite:t:`Munk:1966go`.
+The associated Legendre polynomials of degree :math:`l` and order :math:`m` are calculated in :py:func:`pyTMD.math.legendre` using the explicit formula (1-67) from :cite:t:`HofmannWellenhof:2006hy`:
 
 .. math::
     :label: 9.2

--- a/doc/source/background/Tide-Catalog-Table.rst
+++ b/doc/source/background/Tide-Catalog-Table.rst
@@ -3,7 +3,7 @@
 Tide Potential Catalogs
 -----------------------
 
-``pyTMD`` currently supports the following tide potential catalogs:
+:py:func:`pyTMD.predict.body_tide` currently supports the following tide potential catalogs:
 
 .. _tab-catalogs:
 

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -250,7 +250,7 @@ The three valid data types in ``pyTMD`` are:
     * **Typical Applications:** tide maps, raster imagery, satellite imagery, gridded products, model outputs 
     * **Output Dimensions**: ``(y, x)`` or ``(y, x, time)``
 
-If the ``type`` parameter is not specified to a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
+If the ``type`` argument is set to `None` in a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
 
 Interpolation
 #############

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -201,7 +201,7 @@ For models with multiple constituent files, the files can be found using a ``glo
 Programs
 ########
 
-:py:class:`pyTMD.compute` calculates tide predictions for use with ``numpy`` arrays or ``pandas`` dataframes.
+:py:mod:`pyTMD.compute` calculates tide predictions for use with ``numpy`` arrays or ``pandas`` dataframes.
 These are a series of functions that take ``x``, ``y``, and ``time`` coordinates and
 compute the corresponding tidal elevation or currents.
 
@@ -229,7 +229,7 @@ For other projected models, a formatted coordinate reference system (CRS) descri
 Data Types
 ##########
 
-The :py:class:`pyTMD.compute` functions accept a ``type`` parameter that defines the relationship between the spatial and temporal coordinates and create the output ``xarray.DataArray`` dimensions.
+The :py:mod:`pyTMD.compute` functions accept a ``type`` parameter that defines the relationship between the spatial and temporal coordinates and create the output ``xarray.DataArray`` dimensions.
 The three valid data types in ``pyTMD`` are:
 
 - ``'trajectory'``
@@ -241,7 +241,7 @@ The three valid data types in ``pyTMD`` are:
 - ``'time series'``
 
     * **When to Use:** Spatial coordinates are fixed to location(s) and the temporal coordinate is an array of times
-    * **Typical Applications:** tide gauges, GNSS stations, ocean bottom pressure recorders, moored current meters, instruments that stays in place
+    * **Typical Applications:** tide gauges, GNSS stations, ocean bottom pressure recorders, moored current meters, instruments that stay in place
     * **Output Dimensions**: ``(time, )`` or ``(station, time)``
 
 - ``'grid'``
@@ -250,7 +250,7 @@ The three valid data types in ``pyTMD`` are:
     * **Typical Applications:** tide maps, raster imagery, satellite imagery, gridded products, model outputs 
     * **Output Dimensions**: ``(y, x)`` or ``(y, x, time)``
 
-If the ``type`` parameter is not specified to a :py:class:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
+If the ``type`` parameter is not specified to a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
 
 Interpolation
 #############

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -4,7 +4,7 @@ Getting Started
 
 .. tip::
 
-    See the `background material <../background/Ocean-Load-Tides.html>`_ and `glossary <../background/Glossary.html>`_ for more information on the theory and methods used in ``pyTMD``.
+    See the `background material <../background/Background.html>`_ and `glossary <../background/Glossary.html>`_ for more information on the theory and methods used in ``pyTMD``.
 
 .. note::
 
@@ -201,7 +201,7 @@ For models with multiple constituent files, the files can be found using a ``glo
 Programs
 ########
 
-``pyTMD.compute`` calculates tide predictions for use with ``numpy`` arrays or ``pandas`` dataframes.
+:py:class:`pyTMD.compute` calculates tide predictions for use with ``numpy`` arrays or ``pandas`` dataframes.
 These are a series of functions that take ``x``, ``y``, and ``time`` coordinates and
 compute the corresponding tidal elevation or currents.
 
@@ -225,6 +225,32 @@ The default coordinate system in ``pyTMD`` is WGS84 geodetic coordinates in lati
 Some regional tide models are projected in a different coordinate system.
 These models have their coordinate reference system (CRS) information stored as PROJ descriptors in the `JSON model database <https://github.com/pyTMD/pyTMD/blob/main/pyTMD/data/database.json>`_:
 For other projected models, a formatted coordinate reference system (CRS) descriptor (e.g. ``PROJ``, ``WKT``, or ``EPSG`` code) can be used.
+
+Data Types
+##########
+
+The :py:class:`pyTMD.compute` functions accept a ``type`` parameter that defines the relationship between the spatial and temporal coordinates and create the output ``xarray.DataArray`` dimensions.
+The three valid data types in ``pyTMD`` are:
+
+- ``'trajectory'``
+
+    * **When to Use:** Spatiotemporal coordinates are arrays of the same length and each element represents a single observation
+    * **Typical Applications:** drift buoys, ship tracks, airborne or satellite altimetry, instruments that move through space
+    * **Output Dimensions**: ``(time, )``
+
+- ``'time series'``
+
+    * **When to Use:** Spatial coordinates are fixed to location(s) and the temporal coordinate is an array of times
+    * **Typical Applications:** tide gauges, GNSS stations, ocean bottom pressure recorders, moored current meters, instruments that stays in place
+    * **Output Dimensions**: ``(time, )`` or ``(station, time)``
+
+- ``'grid'``
+
+    * **When to Use:** Spatial coordinates define a 2-dimensional grid and the temporal coordinate is either a scalar or an array of times
+    * **Typical Applications:** tide maps, raster imagery, satellite imagery, gridded products, model outputs 
+    * **Output Dimensions**: ``(y, x)`` or ``(y, x, time)``
+
+If the ``type`` parameter is not specified to a :py:class:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
 
 Interpolation
 #############

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -250,7 +250,7 @@ The three valid data types in ``pyTMD`` are:
     * **Typical Applications:** tide maps, raster imagery, satellite imagery, gridded products, model outputs 
     * **Output Dimensions**: ``(y, x)`` or ``(y, x, time)``
 
-If the ``type`` argument is set to `None` in a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
+If the ``type`` argument is set to ``None`` in a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
 
 Interpolation
 #############

--- a/doc/source/user_guide/Transition_Guide.rst
+++ b/doc/source/user_guide/Transition_Guide.rst
@@ -216,3 +216,5 @@ Renamed Functions
 
 The ``arguments`` module has been renamed ``constituents`` to better reflect its expanded capabilities from the earliest versions.
 
+In version 3, the ``drift`` type has been renamed to ``trajectory`` to better fit `CF Convention geometry types <https://cfconventions.org/cf-conventions/cf-conventions.html>`_.
+The ``drift`` type is still accepted as an alias for ``trajectory`` for backward compatibility, but the new name is recommended for clarity.

--- a/doc/source/user_guide/zarr-predict.py
+++ b/doc/source/user_guide/zarr-predict.py
@@ -27,7 +27,7 @@ df = pd.read_parquet("pytmd-test.parquet")
 ts = timescale.from_deltatime(df.time, epoch=(2018, 1, 1), standard="GPS")
 
 # create xarray DataArrays for coordinates in crs of model
-x, y = ds.tmd.coords_as(df.x, df.y, type="drift", crs=3031)
+x, y = ds.tmd.coords_as(df.x, df.y, type="trajectory", crs=3031)
 # interpolate to points
 local = ds.tmd.interp(x, y, method="linear")
 

--- a/pyTMD/compute.py
+++ b/pyTMD/compute.py
@@ -385,17 +385,9 @@ def tide_elevations(
     if kwargs["constituents"]:
         ds = ds.tmd.subset(kwargs["constituents"])
 
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
-    X, Y = ds.tmd.coords_as(x, y, type=type, crs=crs)
+    X, Y = ds.tmd.coords_as(x, y, type=type, time=delta_time, crs=crs)
 
     # crop tide model dataset to bounds
     if crop and bounds is None:
@@ -582,17 +574,9 @@ def tide_currents(
     if kwargs["constituents"]:
         dtree = dtree.tmd.subset(kwargs["constituents"])
 
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
-    X, Y = dtree.tmd.coords_as(x, y, type=type, crs=crs)
+    X, Y = dtree.tmd.coords_as(x, y, type=type, time=delta_time, crs=crs)
 
     # crop tide model datatree to bounds
     if crop and bounds is None:
@@ -725,11 +709,6 @@ def tide_masks(
     # open model as dataset
     ds = m.open_dataset(group="z")
 
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
     X, Y = ds.tmd.coords_as(x, y, type=type, crs=crs)
@@ -795,18 +774,10 @@ def LPET_elevations(
     _standards = ("datetime", "gps", "loran", "tai", "utc")
     if standard.lower() not in _standards:
         raise ValueError("Unknown time standard")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})
@@ -906,18 +877,10 @@ def LPT_displacements(
     _conventions = timescale.eop._conventions
     if not convention.isdigit() or convention not in _conventions:
         raise ValueError("Invalid IERS Convention")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})
@@ -1076,18 +1039,10 @@ def OPT_displacements(
         raise ValueError("Invalid IERS Convention")
     if method.lower() not in ("linear", "nearest"):
         raise ValueError("Unknown interpolation method")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})
@@ -1291,20 +1246,12 @@ def _ephemerides_SET(
     _methods = ("approximate", "jpl", "kubo", "meeus", "montenbruck")
     if ephemerides.lower() not in _methods:
         raise ValueError("Invalid ephemerides method")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # earth and physical parameters for ellipsoid
     units = pyTMD.earth.datum(ellipsoid=ellipsoid, units="MKS")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})
@@ -1482,18 +1429,10 @@ def _catalog_SET(
     _methods = ("astro5", "cartwright", "iers", "meeus")
     if ephemerides.lower() not in _methods:
         raise ValueError("Invalid ephemerides method")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # geocentric latitude (degrees)
     latitude_geocentric = pyTMD.spatial.geocentric_latitude(latitude)
@@ -1605,21 +1544,13 @@ def TG_forces(
     _methods = ("approximate", "jpl", "kubo", "meeus", "montenbruck")
     if ephemerides.lower() not in _methods:
         raise ValueError("Invalid ephemerides method")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
 
     # earth and physical parameters for ellipsoid
     units = pyTMD.earth.datum(ellipsoid=ellipsoid, units="MKS")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})
@@ -1784,21 +1715,13 @@ def GT_accelerations(
     _methods = ("approximate", "jpl", "kubo", "meeus", "montenbruck")
     if ephemerides.lower() not in _methods:
         raise ValueError("Invalid ephemerides method")
-    # determine input data type based on variable dimensions
-    if not type:
-        type = pyTMD.spatial.data_type(x, y, delta_time)
-    # handle legacy 'drift' type for trajectory data
-    if type.lower() == "drift":
-        type = "trajectory"
-    elif type.lower() not in ("trajectory", "grid", "time series"):
-        raise ValueError("Unknown data type")
 
     # earth and physical parameters for ellipsoid
     units = pyTMD.earth.datum(ellipsoid=ellipsoid, units="MKS")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
     longitude, latitude = pyTMD.io.dataset._coords(
-        x, y, type=type, source_crs=crs, target_crs=4326
+        x, y, type=type, time=delta_time, source_crs=crs, target_crs=4326
     )
     # create dataset
     ds = xr.Dataset(coords={"x": longitude, "y": latitude})

--- a/pyTMD/compute.py
+++ b/pyTMD/compute.py
@@ -65,6 +65,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 06/2026: standardize use of lambda (lmda) to denote longitudes
+        drift type renamed to trajectory. drift still accepted as an alias
     Updated 05/2026: use numpy hypot function to calculate magnitudes
     Updated 05/2026: moved datum ellipsoidal parameters to earth module
     Updated 03/2026: added function for computing tide-generating forces
@@ -261,7 +262,7 @@ def tide_elevations(
     buffer: int | float = 0,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     method: str = "linear",
     extrapolate: bool = False,
@@ -298,11 +299,11 @@ def tide_elevations(
         Input coordinate reference system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -387,7 +388,10 @@ def tide_elevations(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
@@ -466,7 +470,7 @@ def tide_currents(
     buffer: int | float = 0,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     method: str = "linear",
     extrapolate: bool = False,
@@ -503,11 +507,11 @@ def tide_currents(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -581,7 +585,10 @@ def tide_currents(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
@@ -661,7 +668,7 @@ def tide_masks(
     model: str | None = None,
     definition_file: str | pathlib.Path | IOBase | None = None,
     crs: str | int = 4326,
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     method: str = "linear",
     **kwargs,
 ):
@@ -682,6 +689,12 @@ def tide_masks(
         Tide model definition file for use
     crs: str or int, default: 4326 (WGS84 Latitude and Longitude)
         Input coordinate system
+    type: str or NoneType, default 'trajectory'
+        Input data type
+
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
+            - ``'grid'``: spatial grids or images
+            - ``'time series'``: time series at a single point
     method: str, default 'linear'
         Interpolation method from ``xarray``
 
@@ -712,8 +725,10 @@ def tide_masks(
     # open model as dataset
     ds = m.open_dataset(group="z")
 
-    # determine input data type based on variable dimensions
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in coordinate reference system of model
@@ -735,7 +750,7 @@ def LPET_elevations(
     delta_time: np.ndarray,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     **kwargs,
 ):
@@ -754,11 +769,11 @@ def LPET_elevations(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -783,7 +798,10 @@ def LPET_elevations(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
@@ -819,7 +837,7 @@ def LPT_displacements(
     delta_time: np.ndarray,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     ellipsoid: str = "WGS84",
     convention: str = "2018",
@@ -842,11 +860,11 @@ def LPT_displacements(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -891,7 +909,10 @@ def LPT_displacements(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
@@ -978,7 +999,7 @@ def OPT_displacements(
     delta_time: np.ndarray,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     ellipsoid: str = "WGS84",
     convention: str = "2018",
@@ -1002,11 +1023,11 @@ def OPT_displacements(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -1058,7 +1079,10 @@ def OPT_displacements(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
@@ -1190,7 +1214,7 @@ def _ephemerides_SET(
     delta_time: np.ndarray,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     ellipsoid: str = "WGS84",
     tide_system: str = "tide_free",
@@ -1214,11 +1238,11 @@ def _ephemerides_SET(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -1270,7 +1294,10 @@ def _ephemerides_SET(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # earth and physical parameters for ellipsoid
     units = pyTMD.earth.datum(ellipsoid=ellipsoid, units="MKS")
@@ -1368,7 +1395,7 @@ def _catalog_SET(
     delta_time: np.ndarray,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     catalog: str = "CTE1973",
     tide_system: str = "tide_free",
@@ -1393,11 +1420,11 @@ def _catalog_SET(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -1458,7 +1485,10 @@ def _catalog_SET(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
     # convert coordinates to xarray DataArrays
     # in WGS84 Latitude and Longitude
@@ -1504,7 +1534,7 @@ def TG_forces(
     h: float | np.ndarray = 0.0,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     ellipsoid: str = "WGS84",
     ephemerides: str = "Montenbruck",
@@ -1529,11 +1559,11 @@ def TG_forces(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -1578,7 +1608,10 @@ def TG_forces(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
 
     # earth and physical parameters for ellipsoid
@@ -1687,7 +1720,7 @@ def GT_accelerations(
     h: float | np.ndarray = 0.0,
     crs: str | int = 4326,
     epoch: list | tuple = (2000, 1, 1, 0, 0, 0),
-    type: str | None = "drift",
+    type: str | None = "trajectory",
     standard: str = "UTC",
     ellipsoid: str = "WGS84",
     ephemerides: str = "Montenbruck",
@@ -1711,11 +1744,11 @@ def GT_accelerations(
         Input coordinate system
     epoch: tuple, default (2000,1,1,0,0,0)
         Time period for calculating delta times
-    type: str or NoneType, default 'drift'
+    type: str or NoneType, default 'trajectory'
         Input data type
 
             - ``None``: determined from input variable dimensions
-            - ``'drift'``: drift buoys or satellite/airborne altimetry
+            - ``'trajectory'``: drift buoys or satellite/airborne altimetry
             - ``'grid'``: spatial grids or images
             - ``'time series'``: time series at a single point
     standard: str, default 'UTC'
@@ -1754,7 +1787,10 @@ def GT_accelerations(
     # determine input data type based on variable dimensions
     if not type:
         type = pyTMD.spatial.data_type(x, y, delta_time)
-    if type.lower() not in ("drift", "grid", "time series"):
+    # handle legacy 'drift' type for trajectory data
+    if type.lower() == "drift":
+        type = "trajectory"
+    elif type.lower() not in ("trajectory", "grid", "time series"):
         raise ValueError("Unknown data type")
 
     # earth and physical parameters for ellipsoid

--- a/pyTMD/io/dataset.py
+++ b/pyTMD/io/dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 dataset.py
-Written by Tyler Sutterley (05/2026)
+Written by Tyler Sutterley (06/2026)
 An xarray.Dataset extension for tidal model data
 
 PYTHON DEPENDENCIES:
@@ -20,6 +20,8 @@ PYTHON DEPENDENCIES:
         https://docs.xarray.dev/en/stable/
 
 UPDATE HISTORY:
+    Updated 06/2026: moved peak finding algorithm to prediction module
+        drift type renamed to trajectory. drift still accepted as an alias
     Updated 05/2026: added parameters to allow for extrapolation with
         inverse distance weighting (IDW) in addition to nearest-neighbors (NN)
     Updated 04/2026: add barycentric interpolation for unstructured grids
@@ -1243,15 +1245,10 @@ class DataArray:
         low_peaks: xarray.DataArray
             Boolean array indicating locations of low tide peaks
         """
-        # differentiate to calculate high and low tides
-        diff = self._da.differentiate("time", **kwargs)
-        # look for zero crossings in the derivative to find peaks
-        # compare the sign of the derivative with the next time step
-        sign = np.sign(diff)
-        next_sign = sign.shift(time=-1)
-        # get the zero crossings to find the high and low tides
-        high_peaks = (sign >= 0) & (next_sign < 0)
-        low_peaks = (sign <= 0) & (next_sign > 0)
+        from pyTMD.predict import find_peaks as _find_peaks
+
+        # find the high and low tides using a first order differentiation
+        high_peaks, low_peaks = _find_peaks(self._da, dim="time", **kwargs)
         # return the peaks
         return (high_peaks, low_peaks)
 
@@ -1558,7 +1555,7 @@ def _coords(
         If not provided: must specify ``time`` parameter to auto-detect
 
         - ``None``: determined from input variable dimensions
-        - ``'drift'``: drift buoys or satellite/airborne altimetry
+        - ``'trajectory'``: drift buoys or satellite/airborne altimetry
         - ``'grid'``: spatial grids or images
         - ``'time series'``: time series at a single point
     time: np.ndarray or None, default None
@@ -1585,10 +1582,15 @@ def _coords(
     elif kwargs["type"] is None:
         # auto-detect coordinate data type from input variable dimensions
         coord_type = data_type(x, y, np.ravel(kwargs["time"]))
-    else:
+    elif isinstance(kwargs["type"], str) and kwargs["type"].lower() == "drift":
+        # handle legacy 'drift' type for trajectory data
+        coord_type = "trajectory"
+    elif isinstance(kwargs["type"], str):
         # use provided coordinate data type
         # and verify that it is lowercase
         coord_type = kwargs.get("type").lower()
+    else:
+        raise ValueError("Coordinate data type must be a string")
     # convert coordinates to a new coordinate reference system
     if (coord_type == "grid") and (np.size(x) != np.size(y)):
         gridx, gridy = np.meshgrid(x, y)
@@ -1614,7 +1616,7 @@ def _coords(
     elif coord_type == "grid":
         X = xr.DataArray(mx, dims=("y", "x"))
         Y = xr.DataArray(my, dims=("y", "x"))
-    elif coord_type == "drift":
+    elif coord_type == "trajectory":
         X = xr.DataArray(mx, dims=("time"))
         Y = xr.DataArray(my, dims=("time"))
     elif coord_type == "time series":
@@ -1622,5 +1624,8 @@ def _coords(
         Y = xr.DataArray(my, dims=("station"))
     else:
         raise ValueError(f"Unknown coordinate data type: {coord_type}")
+    # set attributes for coordinate type
+    X.attrs["type"] = coord_type
+    Y.attrs["type"] = coord_type
     # return the transformed coordinates
     return (X, Y)

--- a/pyTMD/predict/ocean_load.py
+++ b/pyTMD/predict/ocean_load.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """
 ocean_load.py
-Written by Tyler Sutterley (05/2026)
-Prediction routines for ocean, load and equilibrium tides
+Written by Tyler Sutterley (06/2026)
+Prediction routines for ocean, load and (long-period) equilibrium tides
 
 REFERENCES:
     G. D. Egbert and S. Erofeeva, "Efficient Inverse Modeling of Barotropic
@@ -27,6 +27,7 @@ PROGRAM DEPENDENCIES:
     math.py: Special functions of mathematical physics
 
 UPDATE HISTORY:
+    Updated 06/2026: moved function to find peaks in a tidal time series
     Updated 05/2026: verify unique frequencies in short period inference
         moved ellipsoid and love number parameters to earth module
         updated constituent parameters function can output arrays
@@ -125,6 +126,7 @@ __all__ = [
     "_infer_diurnal",
     "_infer_long_period",
     "equilibrium_tide",
+    "find_peaks",
 ]
 
 # number of days between MJD and the tide epoch (1992-01-01T00:00:00)
@@ -150,7 +152,7 @@ def time_series(
 
     Returns
     -------
-    darr: xarray.DataArray
+    tpred: xarray.DataArray
         Predicted tidal time series
     """
     # set default keyword arguments
@@ -1212,3 +1214,42 @@ def equilibrium_tide(
     tpred.attrs["constituents"] = constituents
     # return the long-period equilibrium tides
     return tpred.tmd.to_units("meters")
+
+
+def find_peaks(
+    darr: xr.DataArray,
+    dim: str = "time",
+    **kwargs,
+):
+    """
+    Find peaks in an xarray ``DataArray`` using a first order
+    differentiation method
+
+    Parameters
+    ----------
+    darr: xarray.DataArray
+        Input ``DataArray`` containing a signal with peaks
+    dim: str, default 'time'
+        Dimension along which to find peaks
+    kwargs: dict
+        Keyword arguments for ``xarray.DataArray.differentiate``
+
+    Returns
+    -------
+    high_peaks: xarray.DataArray
+        Boolean array indicating locations of high peaks
+    low_peaks: xarray.DataArray
+        Boolean array indicating locations of low peaks
+    """
+    # differentiate to calculate high and low peaks
+    diff = darr.differentiate(dim, **kwargs)
+    # look for zero crossings in the derivative to find peaks
+    # compare the sign of the derivative with the next step
+    sign = np.sign(diff)
+    next_sign = sign.shift({dim: -1})
+    # get the zero crossings to find the high and low peaks
+    # checking the gradient of the sign change gives the peak type
+    high_peaks = (sign >= 0) & (next_sign < 0)
+    low_peaks = (sign <= 0) & (next_sign > 0)
+    # return the peaks
+    return (high_peaks, low_peaks)

--- a/pyTMD/spatial.py
+++ b/pyTMD/spatial.py
@@ -13,6 +13,7 @@ PYTHON DEPENDENCIES:
 UPDATE HISTORY:
     Updated 06/2026: use item() to extract scalars from 0-dimensional arrays
         standardize use of lambda (lmda) to denote longitudes
+        drift type renamed to trajectory to better fit CF conventions
     Updated 05/2026: moved datum ellipsoidal parameters to earth module
     Updated 04/2026: updated scale factors to add case where reference
         latitude is at the pole
@@ -132,7 +133,7 @@ def data_type(
     String denoting input data type
 
         - ``'time series'``
-        - ``'drift'``
+        - ``'trajectory'``
         - ``'grid'``
     """
     xsize = np.size(x)
@@ -141,7 +142,7 @@ def data_type(
     if (xsize == 1) and (ysize == 1) and (tsize >= 1):
         return "time series"
     elif (xsize == ysize) & (xsize == tsize):
-        return "drift"
+        return "trajectory"
     elif (np.ndim(x) > 1) & (xsize == ysize):
         return "grid"
     elif xsize != ysize:

--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-u"""
-test_coordinates.py (11/2025)
+"""
+test_coordinates.py (06/2026)
 Verify forward and backwards coordinate conversions
 
 UPDATE HISTORY:
+    Updated 06/2026: test dataset coordinate types and dimensions
     Updated 11/2025: use pyproj.CRS.from_user_input for definitions
     Updated 09/2024: add test for Arctic regions with new projection
         using new JSON dictionary format for model projections
@@ -11,47 +12,183 @@ UPDATE HISTORY:
     Updated 12/2023: use new crs class for coordinate reprojection
     Written 08/2020
 """
+
 import pyproj
+import pytest
 import numpy as np
 import pyTMD
+
 
 # PURPOSE: verify coordinate conversions are close for Arctic regions
 def test_arctic_projection():
     # generate random latitude and longitude coordinates
     N = 10000
-    i1 = -180.0 + 360.0*np.random.rand(N)
-    i2 = 60.0 + 30.0*np.random.rand(N)
+    i1 = -180.0 + 360.0 * np.random.rand(N)
+    i2 = 60.0 + 30.0 * np.random.rand(N)
     # get model projection (simplified polar stereographic)
-    model = pyTMD.models['AOTIM-5-2018']
+    model = pyTMD.models["AOTIM-5-2018"]
     # create transformer from coordinate reference systems
     crs1 = pyproj.CRS.from_user_input(4326)
-    crs2 = pyproj.CRS.from_user_input(model['projection'])
+    crs2 = pyproj.CRS.from_user_input(model["projection"])
     transform = pyproj.Transformer.from_crs(crs1, crs2, always_xy=True)
     # perform forward and inverse transformations
     o1, o2 = transform.transform(i1, i2)
-    lon, lat = transform.transform(o1, o2, direction='INVERSE')
+    lon, lat = transform.transform(o1, o2, direction="INVERSE")
     # calculate great circle distance between inputs and outputs
-    cdist = np.arccos(np.sin(i2*np.pi/180.0)*np.sin(lat*np.pi/180.0) +
-        np.cos(i2*np.pi/180.0)*np.cos(lat*np.pi/180.0)*
-        np.cos((lon-i1)*np.pi/180.0),dtype=np.float32)
+    cdist = np.arccos(
+        np.sin(i2 * np.pi / 180.0) * np.sin(lat * np.pi / 180.0)
+        + np.cos(i2 * np.pi / 180.0)
+        * np.cos(lat * np.pi / 180.0)
+        * np.cos((lon - i1) * np.pi / 180.0),
+        dtype=np.float32,
+    )
     # test that forward and backwards conversions are within tolerance
     eps = np.finfo(np.float32).eps
     assert np.all(cdist < eps)
     # convert projected coordinates from latitude and longitude
-    x = (90.0 - i2)*111.7*np.cos(i1/180.0*np.pi)
-    y = (90.0 - i2)*111.7*np.sin(i1/180.0*np.pi)
+    x = (90.0 - i2) * 111.7 * np.cos(i1 / 180.0 * np.pi)
+    y = (90.0 - i2) * 111.7 * np.sin(i1 / 180.0 * np.pi)
     assert np.allclose(o1, x)
     assert np.allclose(o2, y)
     # convert latitude and longitude from projected coordinates
-    ln = np.arctan2(y, x)*180.0/np.pi
-    lt = 90.0 - np.sqrt(x**2 + y**2)/111.7
+    ln = np.arctan2(y, x) * 180.0 / np.pi
+    lt = 90.0 - np.sqrt(x**2 + y**2) / 111.7
     # adjust longitudes to be -180:180
-    ii, = np.nonzero(ln < 0)
+    (ii,) = np.nonzero(ln < 0)
     ln[ii] += 360.0
     # calculate great circle distance between inputs and outputs
-    cdist = np.arccos(np.sin(lat*np.pi/180.0)*np.sin(lt*np.pi/180.0) +
-        np.cos(lat*np.pi/180.0)*np.cos(lt*np.pi/180.0)*
-        np.cos((lon-ln)*np.pi/180.0),dtype=np.float32)
+    cdist = np.arccos(
+        np.sin(lat * np.pi / 180.0) * np.sin(lt * np.pi / 180.0)
+        + np.cos(lat * np.pi / 180.0)
+        * np.cos(lt * np.pi / 180.0)
+        * np.cos((lon - ln) * np.pi / 180.0),
+        dtype=np.float32,
+    )
     # test that forward and backwards conversions are within tolerance
     eps = np.finfo(np.float32).eps
     assert np.all(cdist < eps)
+
+
+# PURPOSE: verify setting trajectory dataset coordinates
+def test_dataset_trajectory():
+    # test trajectory type
+    exp = "trajectory"
+    # number of data points
+    npts = 30
+    x = np.random.rand(npts)
+    y = np.random.rand(npts)
+    t = np.random.rand(npts)
+    # test with specifying type
+    X, Y = pyTMD.io.dataset._coords(x, y, type=exp, target_crs=4326)
+    assert np.allclose(X.values, x)
+    assert np.allclose(Y.values, y)
+    assert X.dims[0] == "time"
+    assert Y.dims[0] == "time"
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test with legacy drift type
+    X, Y = pyTMD.io.dataset._coords(x, y, type="drift", target_crs=4326)
+    assert np.allclose(X.values, x)
+    assert np.allclose(Y.values, y)
+    assert X.dims[0] == "time"
+    assert Y.dims[0] == "time"
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test without specifying type
+    X, Y = pyTMD.io.dataset._coords(x, y, time=t, target_crs=4326)
+    assert np.allclose(X.values, x)
+    assert np.allclose(Y.values, y)
+    assert X.dims[0] == "time"
+    assert Y.dims[0] == "time"
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+
+
+# PURPOSE: verify setting gridded dataset coordinates
+def test_dataset_grid():
+    # test grid type
+    exp = "grid"
+    # number of data points
+    ny, nx, ntime = 20, 30, 10
+    x = np.random.rand(nx)
+    y = np.random.rand(ny)
+    t = np.random.rand(ntime)
+    xgrid, ygrid = np.meshgrid(x, y)
+    # test with using coordinate arrays
+    X, Y = pyTMD.io.dataset._coords(x, y, type=exp, target_crs=4326)
+    assert np.allclose(X.values, xgrid)
+    assert np.allclose(Y.values, ygrid)
+    assert X.dims == ("y", "x")
+    assert Y.dims == ("y", "x")
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test with using meshgrid directly
+    X, Y = pyTMD.io.dataset._coords(xgrid, ygrid, type=exp, target_crs=4326)
+    assert np.allclose(X.values, xgrid)
+    assert np.allclose(Y.values, ygrid)
+    assert X.dims == ("y", "x")
+    assert Y.dims == ("y", "x")
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test without specifying type
+    X, Y = pyTMD.io.dataset._coords(xgrid, ygrid, time=t, target_crs=4326)
+    assert np.allclose(X.values, xgrid)
+    assert np.allclose(Y.values, ygrid)
+    assert X.dims == ("y", "x")
+    assert Y.dims == ("y", "x")
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+
+# PURPOSE: verify setting time series dataset coordinates
+def test_dataset_time_series():
+    # test time series type
+    exp = "time series"
+    # number of data points
+    nstation, ntime = 1, 10
+    x = np.random.rand(nstation)
+    y = np.random.rand(nstation)
+    t = np.random.rand(ntime)
+    # test with specifying type
+    X, Y = pyTMD.io.dataset._coords(x, y, type=exp, target_crs=4326)
+    assert np.allclose(X.values, x)
+    assert np.allclose(Y.values, y)
+    assert X.dims == ("station",)
+    assert Y.dims == ("station",)
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test without specifying type
+    X, Y = pyTMD.io.dataset._coords(x, y, time=t, target_crs=4326)
+    assert np.allclose(X.values, x)
+    assert np.allclose(Y.values, y)
+    assert X.dims == ("station",)
+    assert Y.dims == ("station",)
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+    # test with scalars
+    X, Y = pyTMD.io.dataset._coords(x[0], y[0], target_crs=4326)
+    assert np.allclose(X.values, x[0])
+    assert np.allclose(Y.values, y[0])
+    assert X.dims == ()
+    assert Y.dims == ()
+    assert X.attrs["type"] == exp
+    assert Y.attrs["type"] == exp
+
+def test_dataset_invalid():
+    # number of data points
+    npts = 30
+    x = np.random.rand(npts)
+    y = np.random.rand(npts)
+    # test catch for unknown data type
+    msg = "Must provide time parameter to determine type"
+    with pytest.raises(ValueError, match=msg):
+        pyTMD.io.dataset._coords(x, y, target_crs=4326)
+    # test catch for unknown data type
+    coord_type = "unknown"
+    msg = f"Unknown coordinate data type: {coord_type}"
+    with pytest.raises(ValueError, match=msg):
+        pyTMD.io.dataset._coords(x, y, type=coord_type, target_crs=4326)
+    # test catch for invalid data type
+    coord_type = ["invalid"]
+    msg = "Coordinate data type must be a string"
+    with pytest.raises(ValueError, match=msg):
+        pyTMD.io.dataset._coords(x, y, type=coord_type, target_crs=4326)

--- a/test/test_equilibrium_tide.py
+++ b/test/test_equilibrium_tide.py
@@ -24,7 +24,7 @@ import pyTMD.math
 import timescale.time
 
 # PURPOSE: test the estimation of long-period equilibrium tides
-@pytest.mark.parametrize("TYPE", ['grid','drift'])
+@pytest.mark.parametrize("TYPE", ['grid', 'trajectory'])
 @pytest.mark.parametrize("include_anelasticity", [False, True])
 def test_equilibrium_tide(TYPE, include_anelasticity):
     """
@@ -33,7 +33,7 @@ def test_equilibrium_tide(TYPE, include_anelasticity):
     Cartwright-Tayler-Edden tables
     """
     # create a test dataset for data type
-    if (TYPE == 'drift'):
+    if (TYPE == 'trajectory'):
         # number of data points
         n_time = 3000
         lon = np.zeros((n_time))

--- a/test/test_love_numbers.py
+++ b/test/test_love_numbers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-u"""
+"""
 test_love_numbers.py (03/2025)
 Verify Body Tide Love numbers for different constituents
 
@@ -8,10 +8,12 @@ UPDATE HISTORY:
     Updated 11/2024: moved love number calculator to arguments
     Written 09/2024
 """
+
 import pytest
 import numpy as np
 import pyTMD.earth
 import pyTMD.constituents
+
 
 def test_love_numbers():
     """
@@ -21,39 +23,39 @@ def test_love_numbers():
     # expected values
     exp = {}
     # diurnal species
-    exp['2q1'] = (0.604, 0.298, 0.0841)
-    exp['sigma1'] = (0.604, 0.298, 0.0841)
-    exp['q1'] = (0.603, 0.298, 0.0841)
-    exp['rho1'] = (0.603, 0.298, 0.0841)
-    exp['o1'] = (0.603, 0.298, 0.0841)
-    exp['tau1'] = (0.603, 0.298, 0.0842)
-    exp['m1'] = (0.600, 0.297, 0.0842)
-    exp['chi1'] = (0.600, 0.296, 0.0843)
-    exp['pi1'] = (0.587, 0.290, 0.0847)
-    exp['p1'] = (0.581, 0.287, 0.0849)
-    exp['s1'] = (0.568, 0.280, 0.0853)
-    exp['k1'] = (0.520, 0.256, 0.0868)
-    exp['psi1'] = (0.937, 0.466, 0.0736)
-    exp['phi1'] = (0.662, 0.328, 0.0823)
-    exp['theta1'] = (0.612, 0.302, 0.0839)
-    exp['j1'] = (0.611, 0.302, 0.0839)
-    exp['so1'] = (0.608, 0.301, 0.0840)
-    exp['oo1'] = (0.608, 0.301, 0.0840)
-    exp['ups1'] = (0.607, 0.300, 0.0840)
+    exp["2q1"] = (0.604, 0.298, 0.0841)
+    exp["sigma1"] = (0.604, 0.298, 0.0841)
+    exp["q1"] = (0.603, 0.298, 0.0841)
+    exp["rho1"] = (0.603, 0.298, 0.0841)
+    exp["o1"] = (0.603, 0.298, 0.0841)
+    exp["tau1"] = (0.603, 0.298, 0.0842)
+    exp["m1"] = (0.600, 0.297, 0.0842)
+    exp["chi1"] = (0.600, 0.296, 0.0843)
+    exp["pi1"] = (0.587, 0.290, 0.0847)
+    exp["p1"] = (0.581, 0.287, 0.0849)
+    exp["s1"] = (0.568, 0.280, 0.0853)
+    exp["k1"] = (0.520, 0.256, 0.0868)
+    exp["psi1"] = (0.937, 0.466, 0.0736)
+    exp["phi1"] = (0.662, 0.328, 0.0823)
+    exp["theta1"] = (0.612, 0.302, 0.0839)
+    exp["j1"] = (0.611, 0.302, 0.0839)
+    exp["so1"] = (0.608, 0.301, 0.0840)
+    exp["oo1"] = (0.608, 0.301, 0.0840)
+    exp["ups1"] = (0.607, 0.300, 0.0840)
     # semi-diurnal species
-    exp['m2'] = (0.609, 0.302, 0.0852)
+    exp["m2"] = (0.609, 0.302, 0.0852)
     # long-period species
-    exp['mm'] = (0.606, 0.299, 0.0840)
+    exp["mm"] = (0.606, 0.299, 0.0840)
     # for each tidal constituent
     for c, v in exp.items():
         # calculate Love numbers
-        omega, = pyTMD.constituents.frequency(c)
-        h2, k2, l2 = pyTMD.earth.love_numbers(
-            omega, model='1066A')
+        (omega,) = pyTMD.constituents.frequency(c)
+        h2, k2, l2 = pyTMD.earth.love_numbers(omega, model="1066A")
         # check Love numbers
         assert np.isclose(h2, v[0], atol=15e-4)
         assert np.isclose(k2, v[1], atol=15e-4)
         assert np.isclose(l2, v[2], atol=15e-4)
+
 
 def test_complex_love_numbers():
     """
@@ -64,33 +66,33 @@ def test_complex_love_numbers():
     # Doodson coefficients
     coefficients = {}
     # diurnal species
-    coefficients['q1'] = [1.0, -2.0, 0.0, 1.0, 0.0, 0.0, -1.0]
-    coefficients['o1'] = [1.0, -1.0, 0.0, 0.0, 0.0, 0.0, -1.0]
-    coefficients['pi1'] = [1.0, 1.0, -3.0, 0.0, 0.0, 1.0, -1.0]
-    coefficients['p1'] = [1.0, 1.0, -2.0, 0.0, 0.0, 0.0, -1.0]
+    coefficients["q1"] = [1.0, -2.0, 0.0, 1.0, 0.0, 0.0, -1.0]
+    coefficients["o1"] = [1.0, -1.0, 0.0, 0.0, 0.0, 0.0, -1.0]
+    coefficients["pi1"] = [1.0, 1.0, -3.0, 0.0, 0.0, 1.0, -1.0]
+    coefficients["p1"] = [1.0, 1.0, -2.0, 0.0, 0.0, 0.0, -1.0]
     # semi-diurnal species
-    coefficients['m2'] = [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    coefficients["m2"] = [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     # long-period species
-    coefficients['055.565'] = [0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0]
-    coefficients['ssa'] = [0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0]
-    coefficients['mm'] = [0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0]
-    coefficients['mf'] = [0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    coefficients['075.565'] = [0.0, 2.0, 0.0, 0.0, -1.0, 0.0, 0.0]
+    coefficients["055.565"] = [0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0]
+    coefficients["ssa"] = [0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0]
+    coefficients["mm"] = [0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0]
+    coefficients["mf"] = [0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    coefficients["075.565"] = [0.0, 2.0, 0.0, 0.0, -1.0, 0.0, 0.0]
     # expected values
     exp = {}
     # diurnal species
-    exp['q1'] = (0.6036 - 0.0026j, 0.29785 - 0.00139j, 0.0846 - 0.0008j)
-    exp['o1'] = (0.6028 - 0.0025j, 0.29747 - 0.00137j, 0.0846 - 0.0008j)
-    exp['pi1'] = (0.5878 - 0.0015j, 0.28996 - 0.00086j, 0.0847 - 0.0007j)
-    exp['p1'] = (0.5817 - 0.0011j, 0.28692 - 0.00067j, 0.0853 - 0.0007j)
+    exp["q1"] = (0.6036 - 0.0026j, 0.29785 - 0.00139j, 0.0846 - 0.0008j)
+    exp["o1"] = (0.6028 - 0.0025j, 0.29747 - 0.00137j, 0.0846 - 0.0008j)
+    exp["pi1"] = (0.5878 - 0.0015j, 0.28996 - 0.00086j, 0.0847 - 0.0007j)
+    exp["p1"] = (0.5817 - 0.0011j, 0.28692 - 0.00067j, 0.0853 - 0.0007j)
     # semi-diurnal species
-    exp['m2'] = (0.6078 - 0.0022j, 0.30102 - 0.0013j, 0.0847 - 0.0007j)
+    exp["m2"] = (0.6078 - 0.0022j, 0.30102 - 0.0013j, 0.0847 - 0.0007j)
     # long-period species
-    exp['055.565'] = (0.6344 - 0.0093j, 0.31537 - 0.00541j, 0.0936 - 0.0028j)
-    exp['ssa'] = (0.6182 - 0.0054j, 0.30593 - 0.00315j, 0.0886 - 0.0016j)
-    exp['mm'] = (0.6126 - 0.0041j, 0.30270 - 0.00237j, 0.0870 - 0.0012j)
-    exp['mf'] = (0.6109 - 0.0037j, 0.30171 - 0.00213j, 0.0864 - 0.0011j)
-    exp['075.565'] = (0.6109 - 0.0037j, 0.30171 - 0.00213j, 0.0864 - 0.0011j)
+    exp["055.565"] = (0.6344 - 0.0093j, 0.31537 - 0.00541j, 0.0936 - 0.0028j)
+    exp["ssa"] = (0.6182 - 0.0054j, 0.30593 - 0.00315j, 0.0886 - 0.0016j)
+    exp["mm"] = (0.6126 - 0.0041j, 0.30270 - 0.00237j, 0.0870 - 0.0012j)
+    exp["mf"] = (0.6109 - 0.0037j, 0.30171 - 0.00213j, 0.0864 - 0.0011j)
+    exp["075.565"] = (0.6109 - 0.0037j, 0.30171 - 0.00213j, 0.0864 - 0.0011j)
     # for each tidal constituent
     for c, v in exp.items():
         # calculate Love numbers
@@ -101,72 +103,74 @@ def test_complex_love_numbers():
         assert np.isclose(k2, v[1], atol=15e-4)
         assert np.isclose(l2, v[2], atol=15e-4)
 
-@pytest.mark.parametrize("model", ['1066A-N', 'PEM-C', 'C2'])
+
+@pytest.mark.parametrize("model", ["1066A-N", "PEM-C", "C2"])
 def test_love_number_ratios(model):
     """
     Tests the calculation of body tide Love numbers compared
     with the values from J. Wahr (1979)
     """
     # expected values for each model
-    exp = {'1066A-N': {}, 'PEM-C': {}, 'C2': {}}
+    exp = {"1066A-N": {}, "PEM-C": {}, "C2": {}}
     # expected values (1066A Neutral)
-    exp['1066A-N']['m1'] = (0.995, 0.997, 1.001)
-    exp['1066A-N']['p1'] = (0.964, 0.963, 1.010)
-    exp['1066A-N']['k1'] = (0.862, 0.859, 1.032)
-    exp['1066A-N']['psi1'] = (1.554, 1.564, 0.875)
-    exp['1066A-N']['phi1'] = (1.098, 1.101, 0.979)
-    exp['1066A-N']['j1'] = (1.013, 1.013, 0.998)
+    exp["1066A-N"]["m1"] = (0.995, 0.997, 1.001)
+    exp["1066A-N"]["p1"] = (0.964, 0.963, 1.010)
+    exp["1066A-N"]["k1"] = (0.862, 0.859, 1.032)
+    exp["1066A-N"]["psi1"] = (1.554, 1.564, 0.875)
+    exp["1066A-N"]["phi1"] = (1.098, 1.101, 0.979)
+    exp["1066A-N"]["j1"] = (1.013, 1.013, 0.998)
     # expected values (PEM-C)
-    exp['PEM-C']['m1'] = (0.995, 0.997, 1.001)
-    exp['PEM-C']['p1'] = (0.964, 0.963, 1.008)
-    exp['PEM-C']['k1'] = (0.862, 0.859, 1.031)
-    exp['PEM-C']['psi1'] = (1.557, 1.567, 0.876)
-    exp['PEM-C']['phi1'] = (1.096, 1.097, 0.979)
-    exp['PEM-C']['j1'] = (1.013, 1.013, 0.998)
+    exp["PEM-C"]["m1"] = (0.995, 0.997, 1.001)
+    exp["PEM-C"]["p1"] = (0.964, 0.963, 1.008)
+    exp["PEM-C"]["k1"] = (0.862, 0.859, 1.031)
+    exp["PEM-C"]["psi1"] = (1.557, 1.567, 0.876)
+    exp["PEM-C"]["phi1"] = (1.096, 1.097, 0.979)
+    exp["PEM-C"]["j1"] = (1.013, 1.013, 0.998)
     # expected values (C2)
-    exp['C2']['m1'] = (0.997, 0.997, 1.001)
-    exp['C2']['p1'] = (0.965, 0.963, 1.008)
-    exp['C2']['k1'] = (0.865, 0.862, 1.031)
-    exp['C2']['psi1'] = (1.565, 1.574, 0.877)
-    exp['C2']['phi1'] = (1.098, 1.101, 0.979)
-    exp['C2']['j1'] = (1.013, 1.013, 0.998)
+    exp["C2"]["m1"] = (0.997, 0.997, 1.001)
+    exp["C2"]["p1"] = (0.965, 0.963, 1.008)
+    exp["C2"]["k1"] = (0.865, 0.862, 1.031)
+    exp["C2"]["psi1"] = (1.565, 1.574, 0.877)
+    exp["C2"]["phi1"] = (1.098, 1.101, 0.979)
+    exp["C2"]["j1"] = (1.013, 1.013, 0.998)
     # frequency of the o1 tidal constituent
-    omega = pyTMD.constituents.frequency('o1')
+    omega = pyTMD.constituents.frequency("o1")
     # calculate Love numbers for o1
     ho1, ko1, lo1 = pyTMD.earth.love_numbers(omega, model=model)
     # for each tidal constituent
     for c, v in exp[model].items():
         # calculate Love numbers
-        omega, = pyTMD.constituents.frequency(c)
+        (omega,) = pyTMD.constituents.frequency(c)
         h2, k2, l2 = pyTMD.earth.love_numbers(omega, model=model)
         # check Love numbers
-        assert np.isclose(h2/ho1, v[0], atol=25e-4)
-        assert np.isclose(k2/ko1, v[1], atol=25e-4)
-        assert np.isclose(l2/lo1, v[2], atol=25e-4)
+        assert np.isclose(h2 / ho1, v[0], atol=25e-4)
+        assert np.isclose(k2 / ko1, v[1], atol=25e-4)
+        assert np.isclose(l2 / lo1, v[2], atol=25e-4)
 
-@pytest.mark.parametrize("model", ['Longman', 'Kaula', 'Takeuchi'])
+
+@pytest.mark.parametrize("model", ["Longman", "Kaula", "Takeuchi"])
 def test_degree_love_numbers(model):
     # expected values for each model
-    exp = {'Longman': {}, 'Kaula': {}, 'Takeuchi': {}}
+    exp = {"Longman": {}, "Kaula": {}, "Takeuchi": {}}
     # expected values (Longman)
-    exp['Longman'][0] = (0.0, 0.0, 0.0)
-    exp['Longman'][2] = (0.612, 0.302, 0.083)
-    exp['Longman'][3] = (0.290, 0.093, 0.014)
-    exp['Longman'][16] = (0.060, 0.003, 0.001)
-    exp['Longman'][17] = (0.058, 0.003, 0.001)
-    exp['Longman'][26] = (0.0, 0.0, 0.0)
+    exp["Longman"][0] = (0.0, 0.0, 0.0)
+    exp["Longman"][2] = (0.612, 0.302, 0.083)
+    exp["Longman"][3] = (0.290, 0.093, 0.014)
+    exp["Longman"][16] = (0.060, 0.003, 0.001)
+    exp["Longman"][17] = (0.058, 0.003, 0.001)
+    exp["Longman"][26] = (0.0, 0.0, 0.0)
     # expected values (Kaula)
-    exp['Kaula'][0] = (0.0, 0.0, 0.0)
-    exp['Kaula'][2] = (0.624, 0.317, 0.085)
-    exp['Kaula'][3] = (0.293, 0.095, 0.014)
-    exp['Kaula'][16] = (0.060, 0.003, 0.001)
-    exp['Kaula'][17] = (0.0, 0.0, 0.0)
+    exp["Kaula"][0] = (0.0, 0.0, 0.0)
+    exp["Kaula"][2] = (0.624, 0.317, 0.085)
+    exp["Kaula"][3] = (0.293, 0.095, 0.014)
+    exp["Kaula"][16] = (0.060, 0.003, 0.001)
+    exp["Kaula"][17] = (0.0, 0.0, 0.0)
     # expected values (Takeuchi)
-    exp['Takeuchi'][0] = (0.0, 0.0, 0.0)
-    exp['Takeuchi'][2] = (0.592, 0.280, 0.076)
-    exp['Takeuchi'][3] = (0.274, 0.083, 0.010)
-    exp['Takeuchi'][16] = (0.048, 0.002, 0.001)
-    exp['Takeuchi'][17] = (0.0, 0.0, 0.0)
+    exp["Takeuchi"][0] = (0.0, 0.0, 0.0)
+    exp["Takeuchi"][2] = (0.592, 0.280, 0.076)
+    exp["Takeuchi"][3] = (0.274, 0.083, 0.010)
+    exp["Takeuchi"][16] = (0.048, 0.002, 0.001)
+    exp["Takeuchi"][17] = (0.0, 0.0, 0.0)
     # for each spherical harmonic degree
     for l, v in exp[model].items():
         # extract love numbers from tables

--- a/test/test_otis_read.py
+++ b/test/test_otis_read.py
@@ -603,8 +603,8 @@ class Test_CATS2008:
         # calculate tide drift corrections
         tide = pyTMD.compute.tide_elevations(x, y, delta_time,
             directory=self.directory, model='CATS2008',
-            epoch=timescale.time._j2000_epoch, type='drift', standard='UTC',
-            crs=3031, extrapolate=True)
+            epoch=timescale.time._j2000_epoch, type='trajectory',
+            standard='UTC', crs=3031, extrapolate=True)
         assert np.any(tide)
 
     # PURPOSE: test the tide currents wrapper function
@@ -623,8 +623,8 @@ class Test_CATS2008:
         # calculate tide drift corrections
         tide = pyTMD.compute.tide_currents(x, y, delta_time,
             directory=self.directory, model='CATS2008',
-            epoch=timescale.time._j2000_epoch, type='drift', standard='UTC',
-            crs=3031, extrapolate=True)
+            epoch=timescale.time._j2000_epoch, type='trajectory',
+            standard='UTC', crs=3031, extrapolate=True)
         # iterate over zonal and meridional currents
         for key,val in tide.items():
             assert np.any(val)

--- a/test/test_pole_tide.py
+++ b/test/test_pole_tide.py
@@ -41,11 +41,11 @@ _jd_tide = _jd_mjd + _mjd_tide
 
 # PURPOSE: compute radial load pole tide displacements
 # following IERS Convention (2010) guidelines
-@pytest.mark.parametrize("TYPE", ['grid','drift','time series'])
+@pytest.mark.parametrize("TYPE", ['grid','trajectory','time series'])
 def test_load_pole_tide_displacements(TYPE):
 
     # create a test dataset for data type
-    if (TYPE == 'drift'):
+    if (TYPE == 'trajectory'):
         # number of data points
         n_time = 3000
         y = np.random.randint(-90,90,size=n_time)
@@ -88,7 +88,7 @@ def test_load_pole_tide_displacements(TYPE):
     elif (TYPE.lower() == 'grid'):
         x = np.atleast_2d(x)
         y = np.atleast_2d(y)
-    elif TYPE.lower() in ('time series', 'drift'):
+    elif TYPE.lower() in ('time series', 'trajectory'):
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
 
@@ -166,7 +166,7 @@ def test_load_pole_tide_displacements(TYPE):
             S = -33.0*np.sin(2.0*theta) * \
                 (mx[i]*np.cos(lmda) + my[i]*np.sin(lmda))
             approx[:,:,i] = np.reshape(S, (ny, nx))/1e3
-    elif (TYPE == 'drift'):
+    elif (TYPE == 'trajectory'):
         Srad = np.ma.zeros((nt), fill_value=FILL_VALUE)
         Srad.data[:] = dfactor*np.sin(2.0*theta) * \
             (mx*np.cos(lmda) + my*np.sin(lmda))

--- a/test/test_solid_earth.py
+++ b/test/test_solid_earth.py
@@ -256,10 +256,10 @@ def test_solid_earth_radial(method):
     tide_expected = tide_earth - tide_earth_free2mean
     # predict radial solid earth tides
     tide_free = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
-        crs=4326, type='drift', standard='datetime', ellipsoid='WGS84',
+        crs=4326, type='trajectory', standard='datetime', ellipsoid='WGS84',
         ephemerides=method)
     tide_mean = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
-        crs=4326, type='drift', standard='datetime', ellipsoid='WGS84',
+        crs=4326, type='trajectory', standard='datetime', ellipsoid='WGS84',
         tide_system='mean_tide', ephemerides=method)
     # as using estimated ephemerides, assert within 1/2 mm
     assert np.allclose(tide_earth, tide_free, atol=5e-4)
@@ -312,10 +312,10 @@ def test_body_tides(catalog, method):
     assert np.allclose(tide_expected, tide_mean['R'], atol=2e-3)
     # predict radial solid earth tides
     tide_free = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
-        crs=4326, type='drift', standard='datetime', tide_system='tide_free',
+        crs=4326, type='trajectory', standard='datetime', tide_system='tide_free',
         method='catalog', ephemerides=method, catalog=catalog)
     tide_mean = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
-        crs=4326, type='drift', standard='datetime', tide_system='mean_tide',
+        crs=4326, type='trajectory', standard='datetime', tide_system='mean_tide',
         method='catalog', ephemerides=method, catalog=catalog)
     # since we are using simplified body tides: assert within 2 mm
     assert np.allclose(tide_earth, tide_free, atol=2e-3)

--- a/test/test_spatial.py
+++ b/test/test_spatial.py
@@ -11,8 +11,8 @@ import pyTMD.spatial
 
 # PURPOSE: test the data type function
 def test_data_type():
-    # test drift type
-    exp = "drift"
+    # test trajectory type
+    exp = "trajectory"
     # number of data points
     npts = 30
     ntime = 30
@@ -326,6 +326,7 @@ def test_polar_scaling():
         lat, reference_latitude=90.0, metric="area"
     )
     assert np.allclose(1.0 / test, expected**2)
+
 
 # PURPOSE: test polar stereographic area scaling factors
 def test_area_scaling():

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-u"""
+"""
 test_utilities.py (12/2020)
 Verify file utility functions
 """
+
 import io
 import gzip
 import pytest
@@ -10,40 +11,44 @@ import pathlib
 import pyTMD.datasets
 import pyTMD.utilities
 
+_default_directory = pyTMD.utilities.get_cache_path()
+
+
 def test_hash():
     # get hash of compressed file
     ocean_pole_tide_file = pyTMD.utilities.get_cache_path(
-        'opoleloadcoefcmcor.txt.gz')
+        "opoleloadcoefcmcor.txt.gz"
+    )
     # fetch file if it doesn't exist
     if not ocean_pole_tide_file.exists():
-        pyTMD.datasets.fetch_iers_opole(
-            directory=ocean_pole_tide_file.parent
-        )
+        pyTMD.datasets.fetch_iers_opole(directory=ocean_pole_tide_file.parent)
     TEST = pyTMD.utilities.get_hash(ocean_pole_tide_file)
-    assert (TEST == '9c66edc2d0fbf627e7ae1cb923a9f0e5')
-    TEST = pyTMD.utilities.get_hash(ocean_pole_tide_file, include_algorithm=True)
-    assert (TEST == 'md5:9c66edc2d0fbf627e7ae1cb923a9f0e5')
+    assert TEST == "9c66edc2d0fbf627e7ae1cb923a9f0e5"
+    TEST = pyTMD.utilities.get_hash(
+        ocean_pole_tide_file, include_algorithm=True
+    )
+    assert TEST == "md5:9c66edc2d0fbf627e7ae1cb923a9f0e5"
     # get hash of uncompressed file
     with gzip.open(ocean_pole_tide_file) as fid:
         TEST = pyTMD.utilities.get_hash(io.BytesIO(fid.read()))
-        assert (TEST == 'cea08f83d613ed8e1a81f3b3a9453721')
+        assert TEST == "cea08f83d613ed8e1a81f3b3a9453721"
 
-_default_directory = pyTMD.utilities.get_cache_path()
+
 def test_valid_url():
     # test over some valid urls
     URLS = [
-        'https://arcticdata.io/',
-        'http://www.esr.org/research/polar-tide-models',
-        's3://pytmd-scratch/CATS2008.zarr'
+        "https://arcticdata.io/",
+        "http://www.esr.org/research/polar-tide-models",
+        "s3://pytmd-scratch/CATS2008.zarr",
     ]
     for URL in URLS:
         url = pyTMD.utilities.Path(URL).resolve()
         assert pyTMD.utilities.is_valid_url(url)
     # test over some file paths
     PATHS = [
-        pathlib.PurePosixPath('/home/user/data/CATS2008/grid_CATS2008'),
-        pathlib.PureWindowsPath('C://Users/user/data/CATS2008/grid_CATS2008'),
-        _default_directory.joinpath('CATS2008','grid_CATS2008')
+        pathlib.PurePosixPath("/home/user/data/CATS2008/grid_CATS2008"),
+        pathlib.PureWindowsPath("C://Users/user/data/CATS2008/grid_CATS2008"),
+        _default_directory.joinpath("CATS2008", "grid_CATS2008"),
     ]
     for PATH in PATHS:
         path = pyTMD.utilities.Path(PATH).resolve()


### PR DESCRIPTION
docs: add section on detecting high and low tides
refactor: name `drift` type to `trajectory` to fit CF conventions (`drift` still accepted as an alias)
test: add tests for setting `Dataset` coordinate types
test: `ruff` format some test modules
