### PR TITLE
feat: add `PYTMD_CACHE_DIR` environ for overriding default cache

### DIFF
--- a/doc/source/api_reference/datasets/datasets.rst
+++ b/doc/source/api_reference/datasets/datasets.rst
@@ -10,6 +10,7 @@ Utilities for fetching and managing tidal datasets
     fetch_arcticdata.rst
     fetch_aviso_fes.rst
     fetch_box_tpxo.rst
+    fetch_database.rst
     fetch_gsfc_got.rst
     fetch_iers_opole.rst
     fetch_jpl_ssd.rst

--- a/doc/source/api_reference/datasets/fetch_database.rst
+++ b/doc/source/api_reference/datasets/fetch_database.rst
@@ -1,0 +1,21 @@
+=================================
+``pyTMD.datasets.fetch_database``
+=================================
+
+- Downloads an updated model JSON database file from the `project GitHub repository <https://github.com/pyTMD/pyTMD>`_
+
+`Source code`__
+
+.. __: https://github.com/pyTMD/pyTMD/blob/main/pyTMD/datasets/fetch_database.py
+
+.. autofunction:: pyTMD.datasets.fetch_database
+
+CLI
+===
+
+.. argparse::
+    :module: pyTMD.datasets.fetch_database
+    :func: arguments
+    :prog: fetch_database.py
+    :nodescription:
+    :nodefault:

--- a/doc/source/background/Background.rst
+++ b/doc/source/background/Background.rst
@@ -1,3 +1,5 @@
+.. _background:
+
 ==========
 Background
 ==========

--- a/doc/source/background/Glossary.rst
+++ b/doc/source/background/Glossary.rst
@@ -1,3 +1,5 @@
+.. _tide-glossary:
+
 ========
 Glossary
 ========

--- a/doc/source/getting_started/Code-of-Conduct.rst
+++ b/doc/source/getting_started/Code-of-Conduct.rst
@@ -1,2 +1,4 @@
+.. _code-of-conduct:
+
 .. include:: ../../../CODE_OF_CONDUCT.md
     :parser: commonmark

--- a/doc/source/getting_started/Contributing.rst
+++ b/doc/source/getting_started/Contributing.rst
@@ -7,8 +7,8 @@ Contribution Guidelines
 ``pyTMD`` is an open source project.
 We welcome any help in maintaining and developing the software and documentation.
 Anyone at *any career stage and with any level of coding experience* can contribute towards the development of ``pyTMD``.
-Please read our `code of conduct <./Code-of-Conduct.html>`_ before contributing to ``pyTMD`` development.
-You will be recognized for your work by being listed as one of the `project contributors <../project/Contributors.html>`_.
+Please read our :ref:`code of conduct <code-of-conduct>` before contributing to ``pyTMD`` development.
+You will be recognized for your work by being listed as one of the :ref:`project contributors <contributors>`.
 
 .. note::
 
@@ -21,7 +21,7 @@ Ways to Contribute
 1) Fixing typographical or coding errors
 2) Submitting bug reports or feature requests through the use of `GitHub issues <https://github.com/pyTMD/pyTMD/issues>`_
 3) Improving documentation and testing
-4) Sharing use cases and examples (such as `Jupyter Notebooks <../user_guide/Examples.html>`_)
+4) Sharing use cases and examples (such as :ref:`Jupyter Notebooks <examples>`)
 5) Providing code for everyone to use
 6) Adding model providers to the database
 
@@ -45,13 +45,13 @@ Contributing Code
 =================
 
 We follow a standard Forking Workflow for code changes and additions.
-Submitted code goes through the pull request process for `continuous integration (CI) testing <../project/Testing.html#continuous-integration>`_ and comments.
+Submitted code goes through the pull request process for :ref:`continuous integration (CI) testing <ci-testing>` and comments.
 
 General Guidelines
 ------------------
 
 - Make each pull request as small and simple as possible
-- `Commit messages should be clear and describe the changes <./Contributing.html#semantic-commit-messages>`_
+- :ref:`Commit messages should be clear and describe the changes <semantic-commits>`
 - Larger changes should be broken down into their basic components and integrated separately
 - Bug fixes should be their own pull requests with an associated `GitHub issue <https://github.com/pyTMD/pyTMD/issues>`_
 - Write a descriptive pull request message with a clear title
@@ -71,7 +71,7 @@ Steps to Contribute
 Adding Examples
 ---------------
 
-Examples may be in the form of executable scripts or interactive `Jupyter Notebooks <../user_guide/Examples.html>`_.
+Examples may be in the form of executable scripts or interactive :ref:`Jupyter Notebooks <examples>`.
 Fully working (but unrendered) examples should be submitted with the same steps as above.
 Many examples can be rendered when the project documentation is built on `Read the Docs <https://about.readthedocs.com/>`_.
 
@@ -80,6 +80,8 @@ Adding Model Providers
 
 Model providers can be added to their respective `JSON files <https://github.com/pyTMD/pyTMD/tree/main/providers>`_.
 The main database can then be updated by running the `merge providers <https://github.com/pyTMD/pyTMD/blob/main/providers/_providers_to_database.py>`_ script.
+
+.. _semantic-commits:
 
 Semantic Commit Messages
 ------------------------
@@ -99,5 +101,5 @@ where ``<type>`` is one of the following:
 - ``docs``: changing the documentation
 - ``style``: changing the line order or adding comments
 - ``refactor``: changing the names of variables or programs
-- ``ci``: changing the `continuous integration <../project/Testing.html#continuous-integration>`_ configuration files or scripts
-- ``test``: adding or updating `continuous integration tests <../project/Testing.html#continuous-integration>`_
+- ``ci``: changing the :ref:`continuous integration <ci-testing>` configuration files or scripts
+- ``test``: adding or updating :ref:`continuous integration tests <ci-testing>`

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -4,14 +4,10 @@ Getting Started
 
 .. tip::
 
-    See the `background material <../background/Background.html>`_ and `glossary <../background/Glossary.html>`_ for more information on the theory and methods used in ``pyTMD``.
-
-.. note::
-
-    If you have previously used ``pyTMD``, check out the :ref:`transition-guide-v3` for information on changes incorporated in Version 3.
+    See the :ref:`Jupyter notebooks <examples>` and :ref:`recipes <recipes>` as a quickstart guide for using ``pyTMD``.
 
 Tide Corrections
-################
+================
 
 Different measurement techniques can have different `vertical datums <https://www.esr.org/data-products/antarctic_tg_database/ocean-tide-and-ocean-tide-loading/>`_, and require different sets of tidal corrections.
 Tide gauges measure the height of the ocean surface *relative to the land* upon which they are situated (*ocean tides only*).
@@ -19,49 +15,9 @@ Satellite altimeters measure the height of the ocean surface *relative to the ce
 
 .. include:: Tide-Corrections.rst
 
-Tide Model Formats
-##################
-
-Ocean and load tide constituent files are available from different modeling groups in different formats.
-``pyTMD`` can access the harmonic constituents for the OTIS, GOT and FES families of ocean and load tide models.
-Choosing a model is often a balance between the spatial resolution of the model, the accuracy of the model (e.g. the underlying physics and if it included data assimilation), the number of constituents included in the model, and the geographic region of interest.
-Another non-trivial consideration is if the model is openly available for download or if it requires registration and/or manual downloading.
-Post on the ``pyTMD`` `discussions board <https://github.com/pyTMD/pyTMD/discussions>`_ if you want more information or help choosing a model.
-
-OTIS and ATLAS formatted data use binary files to store the constituent data for either heights (``z``) or zonal and meridional transports (``u``, ``v``).
-They can be either a single file containing all the constituents (compact) or multiple files each containing a single constituent.
-ATLAS netCDF formatted data use netCDF4 files for each constituent and variable type (``z``, ``u``, ``v``).
-GOT formatted data use ascii or netCDF4 files for each height constituent (``z``).
-FES formatted data use either ascii (1999, 2004) or netCDF4 (2012, 2014) files for each constituent and variable type (``z``, ``u``, ``v``).
-FES also provides unstructured ("native") netCDF4 files, which contain data for all constituents on a finite element mesh.
-
-.. _data-access:
-
-Data Access
-###########
-
-Some tide models can be programmatically downloaded using the fetching routines in ``pyTMD.datasets``.
-OTIS-formatted Arctic Ocean models can be downloaded from the NSF ArcticData server using the :py:func:`pyTMD.datasets.fetch_arcticdata` function.
-GOT models can be downloaded from the NASA GSFC server using the :py:func:`pyTMD.datasets.fetch_gsfc_got` function.
-Users registered with AVISO [see :ref:`aviso-registration`] can download FES models from their FTP server using the :py:func:`pyTMD.datasets.fetch_aviso_fes` function.
-
-Other tide models may require manual downloading due to licensing agreements or limitations on programmatic access.
-TPXO models (OTIS and ATLAS formats) can be requested from the data producers after `registration <https://www.tpxo.net/tpxo-products-and-registration>`_.
-OTIS-formatted Antarctic models are available from the U.S. Antarctic Program Data Center (USAP-DC), which uses a reCAPTCHA security system to prevent automated access.
-See the model links in :ref:`directories` for the references to specific tide models.
-
-.. _model-database:
-
-Model Database
-##############
-
-``pyTMD`` comes parameterized with models for the prediction of tidal elevations and currents.
-All presently available models are stored within a `JSON database <https://github.com/pyTMD/pyTMD/blob/main/pyTMD/data/database.json>`_:
-
-.. include:: Model-Database.ipynb
-   :parser: myst_nb.docutils_
-
-``pyTMD`` currently supports several solutions from the following tide models:
+``pyTMD`` is intended to be able to compute ocean, solid Earth, load and pole tide variations to support the different measurement techniques.
+For ocean and load tides, ``pyTMD`` uses pre-computed tidal constituent files of amplitude and phase provided by tide modeling groups.
+Versions of the following tide models are currently supported [see :ref:`model-selection`]:
 
 - Arctic Ocean (AO) and Greenland coast (Gr) tidal simulations :cite:p:`Padman:2004hv`
 - Circum-Antarctic Tidal Simulations (CATS) :cite:p:`Padman:2008ec`
@@ -72,16 +28,81 @@ All presently available models are stored within a `JSON database <https://githu
 - Technical University of Denmark (DTU) tide models :cite:p:`Andersen:2023ei`
 - TOPEX/POSEIDON (TPXO) global tide models :cite:p:`Egbert:2002ge`
 
+
+.. _model-selection:
+
+Choosing a Model
+================
+
+``pyTMD`` can access the harmonic constituents for the OTIS, GOT and FES families of ocean and load tide models.
+Choosing a model is often a balance between the spatial resolution of the model, the accuracy of the model (e.g. the underlying physics and if it included data assimilation), the number of constituents included in the model, and the geographic region of interest.
+Another non-trivial consideration is if the model is openly available for download or if it requires registration and/or manual downloading.
+Post on the ``pyTMD`` `discussions board <https://github.com/pyTMD/pyTMD/discussions>`_ if you want more information or help choosing a model.
+
+
+Tide Model Formats
+==================
+
+OTIS and ATLAS
+--------------
+
+OTIS and ATLAS formatted data use binary files to store the constituent data for either heights (``z``) or zonal and meridional transports (``u``, ``v``).
+They can be either a single file containing all the constituents (compact) or multiple files each containing a single constituent.
+ATLAS netCDF formatted data use netCDF4 files for each constituent and variable type (``z``, ``u``, ``v``).
+OTIS and ATLAS binary files can be read via the routines in :py:mod:`pyTMD.io.OTIS` and ATLAS netCDF files via the routines in :py:mod:`pyTMD.io.ATLAS`.
+
+GOT
+---
+
+GOT formatted data use ascii or netCDF4 files for each height constituent (``z``).
+Both ascii and netCDF4 files can be read via the routines in :py:mod:`pyTMD.io.GOT`.
+
+FES
+---
+
+FES formatted data use either ascii (1999, 2004) or netCDF4 (2012, 2014) files for each constituent and variable type (``z``, ``u``, ``v``).
+FES also provides unstructured ("native") netCDF4 files, which contain data for all constituents on a finite element mesh.
+All FES files can be read via the routines in :py:mod:`pyTMD.io.FES`.
+
+
+.. _data-access:
+
+Data Access
+===========
+
+Some tide models can be programmatically downloaded using the fetching routines in :py:mod:`pyTMD.datasets`.
+OTIS-formatted Arctic Ocean models can be downloaded from the NSF ArcticData server using the :py:func:`pyTMD.datasets.fetch_arcticdata` function.
+GOT models can be downloaded from the NASA GSFC server using the :py:func:`pyTMD.datasets.fetch_gsfc_got` function.
+Users registered with AVISO [see :ref:`aviso-registration`] can download FES models from their FTP server using the :py:func:`pyTMD.datasets.fetch_aviso_fes` function.
+
+Other tide models may require manual downloading due to licensing agreements or limitations on programmatic access.
+TPXO models (OTIS and ATLAS formats) can be requested from the data producers after `registration <https://www.tpxo.net/tpxo-products-and-registration>`_.
+OTIS-formatted Antarctic models are available from the U.S. Antarctic Program Data Center (USAP-DC), which uses a reCAPTCHA security system to prevent automated access.
+See the model links in :ref:`directories` for the references to specific tide models.
+
+
+.. _model-database:
+
+Model Database
+==============
+
+``pyTMD`` comes with a  `JSON database <https://github.com/pyTMD/pyTMD/blob/main/pyTMD/data/database.json>`_ of models for the prediction of tidal elevations and currents.
+An updated version of the database can be downloaded from the `project <https://github.com/pyTMD/pyTMD>`_ using the :py:func:`pyTMD.datasets.fetch_database` function.
+
+.. include:: Model-Database.ipynb
+   :parser: myst_nb.docutils_
+
+
 .. _directories:
 
 Directories
-###########
+===========
 
 ``pyTMD`` uses a tree structure for storing and accessing the tidal constituent data.
-This structure was chosen based on the different formats of each tide model.
 The base of the tree structure (in the table below as ``<model_path>``) can be the default ``pyTMD`` cache directory or a user-specified (external) directory.
-Several models can be programmatically downloaded from their providers to their parameterized directories using the fetching routines in ``pyTMD.datasets``.
+The default cache directory is set by the ``platformdirs`` package, but can be overridden on a machine by setting the ``PYTMD_CACHE_DIR`` environment variable.
 
+The tree structure was chosen based on the different formats of each tide model.
 Presently, the following models and their directories are parameterized within ``pyTMD``:
 
 .. csv-table::
@@ -92,18 +113,19 @@ Presently, the following models and their directories are parameterized within `
 .. tip::
     See :ref:`tab-currents` for the table of directories for models with tidal currents.
 
-For other tide models, the model parameters can be set with a `model definition file <./Getting-Started.html#definition-files>`_.
-If you wish to add a new model to the ``pyTMD`` database, please see the `contribution guidelines <./Contributing.html>`_.
+For other tide models, the model parameters can be set with a :ref:`model definition file <definition-files>`.
+If you wish to add a new model to the ``pyTMD`` database, please see the :ref:`contribution guidelines <contributing>`.
 
 .. note::
     Any model parameterized with a definition file or added to the database will have to fit a presently supported file standard.
 
+
 .. _definition-files:
 
 Definition Files
-################
+================
 
-For models not currently within the ``pyTMD`` `database <./Getting-Started.html#model-database>`_, the model parameters can be set in :py:class:`pyTMD.io.model` with a definition file in JSON format.
+For models not currently within the ``pyTMD`` :ref:`database <model-database>`, the model parameters can be set in :py:class:`pyTMD.io.model` with a definition file in JSON format.
 The JSON definition files follow a similar structure as the main ``pyTMD`` database, but for individual entries.
 The JSON format directly maps the parameter names with their values stored in the appropriate data type (strings, lists, numbers, booleans, etc).
 While still human readable, the JSON format is both interoperable and more easily machine readable.
@@ -116,7 +138,7 @@ For models with multiple constituent files, the files can be found using a ``glo
 
     * ``format``: ``OTIS``, ``ATLAS-compact`` or ``TMD3``
     * ``name``: tide model name
-    * ``projection``: `model spatial projection <./Getting-Started.html#spatial-coordinates>`_.
+    * ``projection``: :ref:`model spatial projection <spatial-coordinates>`.
     * ``z``:
 
         - ``grid_file``: path to model grid file
@@ -196,7 +218,7 @@ For models with multiple constituent files, the files can be found using a ``glo
 
 
 Units
-#####
+=====
 
 ``pyTMD`` uses ``pint`` to handle the units of the model constituent data and convert them into standard sets of units.
 
@@ -210,7 +232,7 @@ Units
 
 
 Time
-####
+====
 
 The default time in ``pyTMD`` is days (UTC) since a given epoch.
 For ocean, load and equilibrium tide programs, the epoch is 1992-01-01T00:00:00.
@@ -222,7 +244,7 @@ For pole tide programs, the epoch is 1858-11-17T00:00:00 (Modified Julian Days).
 .. _spatial-coordinates:
 
 Spatial Coordinates
-###################
+===================
 
 The default coordinate system in ``pyTMD`` is WGS84 geodetic coordinates in latitude and longitude.
 ``pyTMD`` uses ``pyproj`` to convert from different coordinate systems and datums.
@@ -230,9 +252,27 @@ Some regional tide models are projected in a different coordinate system.
 These models have their coordinate reference system (CRS) information stored as PROJ descriptors in the `JSON model database <https://github.com/pyTMD/pyTMD/blob/main/pyTMD/data/database.json>`_:
 For other projected models, a formatted coordinate reference system (CRS) descriptor (e.g. ``PROJ``, ``WKT``, or ``EPSG`` code) can be used.
 
+.. _interpolation:
+
+Interpolation
+=============
+
+For converting from model coordinates, ``pyTMD`` uses the ``linear`` and ``nearest`` spatial interpolation routines from ``xarray``.
+
+.. important::
+    If the model domain does not contain the coordinates, the interpolation will return ``NaN`` values.
+    Verify that the coordinates are in the model domain and coordinate reference system.
+
+For coastal or near-grounded points, the model can be extrapolated outside the model domain with :py:func:`pyTMD.interpolate.extrapolate` using a nearest-neighbor (NN) or inverse distance weighting (IDW) algorithm [see :ref:`extrapolate-demo`].
+The default maximum extrapolation distance is 10 kilometers.
+This default distance may not be a large enough extrapolation for some applications and models.
+
+.. warning::
+    The extrapolation cutoff can be set to any distance (including infinite), but should be used with caution in cases such as estuaries, narrow fjords or ice sheet grounding zones :cite:p:`Padman:2018cv`.
+
 
 Programs
-########
+========
 
 :py:mod:`pyTMD.compute` calculates tide predictions for use with ``numpy`` arrays or ``pandas`` dataframes.
 These are a series of functions that take ``x``, ``y``, and ``time`` coordinates and
@@ -243,7 +283,7 @@ compute the corresponding tidal elevation or currents.
 
 
 Data Types
-##########
+==========
 
 The :py:mod:`pyTMD.compute` functions accept a ``type`` parameter that defines the relationship between the spatial and temporal coordinates and create the output ``xarray.DataArray`` dimensions.
 The three valid data types in ``pyTMD`` are:
@@ -268,20 +308,6 @@ The three valid data types in ``pyTMD`` are:
 
 If the ``type`` argument is set to ``None`` in a :py:mod:`pyTMD.compute` function, :py:func:`pyTMD.spatial.data_type` will try to auto-detect it based on the dimension sizes.
 
-.. _interpolation:
+.. tip::
 
-Interpolation
-#############
-
-For converting from model coordinates, ``pyTMD`` uses the ``linear`` and ``nearest`` spatial interpolation routines from ``xarray``.
-
-.. important::
-    If the model domain does not contain the coordinates, the interpolation will return ``NaN`` values.
-    Verify that the coordinates are in the model domain and coordinate reference system.
-
-For coastal or near-grounded points, the model can be extrapolated outside the model domain with :py:func:`pyTMD.interpolate.extrapolate` using a nearest-neighbor (NN) or inverse distance weighting (IDW) algorithm [see :ref:`extrapolate-demo`].
-The default maximum extrapolation distance is 10 kilometers.
-This default distance may not be a large enough extrapolation for some applications and models.
-
-.. warning::
-    The extrapolation cutoff can be set to any distance (including infinite), but should be used with caution in cases such as estuaries, narrow fjords or ice sheet grounding zones :cite:p:`Padman:2018cv`.
+    See the :ref:`background material <background>` and :ref:`glossary <tide-glossary>` for more information on the theory and methods.

--- a/doc/source/getting_started/Install.ipynb
+++ b/doc/source/getting_started/Install.ipynb
@@ -39,6 +39,8 @@
    "id": "af65ece3",
    "metadata": {},
    "source": [
+    "(development-install)=\n",
+    "\n",
     "## Development Install\n",
     "\n",
     "To use the development repository, please fork `pyTMD` into your own account and then clone onto your system:\n",
@@ -138,11 +140,35 @@
     "\n",
     "print(f\"pyTMD version: {pyTMD.__version__}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c110ff4",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "The `pyTMD` cache directory is the default location for downloaded tide model and auxiliary data.\n",
+    "The default cache directory is platform independent and set by the `platformdirs` package.\n",
+    "This parametrized path can be _persistently_ overridden on a machine by setting the `PYTMD_CACHE_DIR` environment variable.\n",
+    "\n",
+    "The location of the cache directory used by `pyTMD` can be checked by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad800ca5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyTMD.utilities.get_cache_path()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py13",
    "language": "python",
    "name": "python3"
   },

--- a/doc/source/getting_started/Install.ipynb
+++ b/doc/source/getting_started/Install.ipynb
@@ -149,7 +149,7 @@
     "## Configuration\n",
     "\n",
     "The `pyTMD` cache directory is the default location for downloaded tide model and auxiliary data.\n",
-    "The default cache directory is platform independent and set by the `platformdirs` package.\n",
+    "The default cache directory is platform-specific and set by the `platformdirs` package.\n",
     "This parametrized path can be _persistently_ overridden on a machine by setting the `PYTMD_CACHE_DIR` environment variable.\n",
     "\n",
     "The location of the cache directory used by `pyTMD` can be checked by:"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,6 +5,10 @@ pyTMD Documentation
 Welcome to the documentation for ``pyTMD``, a Python-based tidal prediction software.
 This documentation is intended to explain how to compute ocean, solid Earth, load and pole tide variations using the set of ``pyTMD`` programs.
 
+.. note::
+
+    If you have previously used ``pyTMD``, check out the :ref:`transition-guide-v3` for information on changes incorporated in Version 3.
+
 Introduction
 ============
 

--- a/doc/source/project/Contributors.rst
+++ b/doc/source/project/Contributors.rst
@@ -1,3 +1,6 @@
+
+.. _contributors:
+
 ============
 Contributors
 ============

--- a/doc/source/project/Testing.rst
+++ b/doc/source/project/Testing.rst
@@ -3,7 +3,7 @@ Testing
 =======
 
 ``pyTMD`` uses the ``pytest`` framework to run tests and verify outputs.
-Running the test suite requires a `dev installation <../getting_started/Install.html>`_ of the ``pyTMD`` package to include all of the optional dependencies.
+Running the test suite requires a :ref:`dev installation <development-install>` of the ``pyTMD`` package to include all of the optional dependencies.
 
 .. code-block:: bash
 
@@ -12,9 +12,9 @@ Running the test suite requires a `dev installation <../getting_started/Install.
 Test Data Access
 ================
 
-The test suite requires access to some tide model data files [see `Data Access <../getting_started/Getting-Started.html#data-access>`_].
+The test suite requires access to some tide model data files [see :ref:`Data Access <data-access>`].
 For project developers, the data files can be fetched from a permanent open research repository (``figshare`` or ``zenodo``) using the :py:func:`pyTMD.datasets.fetch_test_data` function.
-These files are similarly accessed during `continuous integration (CI) testing <./Testing.html#continuous-integration>`_.
+These files are similarly accessed during :ref:`continuous integration (CI) testing <ci-testing>`.
 
 Fetching the data using ``pixi``:
 
@@ -65,6 +65,8 @@ To run in series and disable parallelization, set the number of processes to 0:
 .. code-block:: bash
 
     pixi run test "-n 0"
+
+.. _ci-testing:
 
 Continuous Integration
 ======================

--- a/doc/source/user_guide/Cloud-Access.rst
+++ b/doc/source/user_guide/Cloud-Access.rst
@@ -3,7 +3,7 @@ Cloud Data Access
 =================
 
 .. important::
-  Running these example recipes requires an `aws installation <../getting_started/Install.html>`_ to include the optional dependencies.
+  Running these example recipes requires an :ref:`aws installation <development-install>` to include the optional dependencies.
 
 Access a model hosted on s3
 ===========================

--- a/doc/source/user_guide/Examples.rst
+++ b/doc/source/user_guide/Examples.rst
@@ -5,9 +5,9 @@ Examples
 ========
 
 .. important::
-  Running the example notebooks requires a `full installation <../getting_started/Install.html>`_ to include all of the optional dependencies.
+  Running the example notebooks requires a full :ref:`installation <development-install>` to include all of the optional dependencies.
 
-  Some notebooks require first downloading a tide model [see details on `data access <../getting_started/Getting-Started.html#data-access>`_].
+  Some notebooks require first downloading a tide model [see details on :ref:`data access <data-access>`].
 
 .. toctree::
    :maxdepth: 1
@@ -106,4 +106,4 @@ Examples
 
 
 .. tip::
-  More examples can be found on the `Recipes <./Recipes.html>`_ page and in the `Tutorials <https://github.com/pyTMD/pyTMD-tutorial>`_ repository!
+  More examples can be found on the :ref:`recipes` page and in the `Tutorials <https://github.com/pyTMD/pyTMD-tutorial>`_ repository!

--- a/pyTMD/datasets/__init__.py
+++ b/pyTMD/datasets/__init__.py
@@ -5,6 +5,7 @@ Utility functions for downloading or subsetting tidal data
 from .fetch_arcticdata import fetch_arcticdata
 from .fetch_aviso_fes import fetch_aviso_fes
 from .fetch_box_tpxo import fetch_box_tpxo
+from .fetch_database import fetch_database
 from .fetch_gsfc_got import fetch_gsfc_got
 from .fetch_iers_opole import fetch_iers_opole
 from .fetch_jpl_ssd import fetch_jpl_ssd
@@ -16,6 +17,7 @@ fetch = type("fetch", (), {})
 fetch.arcticdata = fetch_arcticdata
 fetch.aviso_fes = fetch_aviso_fes
 fetch.box_tpxo = fetch_box_tpxo
+fetch.database = fetch_database
 fetch.gsfc_got = fetch_gsfc_got
 fetch.iers_opole = fetch_iers_opole
 fetch.jpl_ssd = fetch_jpl_ssd

--- a/pyTMD/datasets/fetch_database.py
+++ b/pyTMD/datasets/fetch_database.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""
+fetch_database.py
+Written by Tyler Sutterley (06/2026)
+Downloads an updated pyTMD model JSON database file from the
+project GitHub repository
+
+COMMAND LINE OPTIONS:
+    --help: list the command line options
+    -t X, --timeout X: timeout in seconds for blocking operations
+    -M X, --mode X: Local permissions mode of the files downloaded
+
+PROGRAM DEPENDENCIES:
+    utilities.py: download and management utilities for syncing files
+
+UPDATE HISTORY:
+    Written 06/2026
+"""
+
+import os
+import logging
+import argparse
+import pyTMD.utilities
+
+
+# PURPOSE: downloads a newer version of a pyTMD database file
+def fetch_database(
+    username: str = "pyTMD",
+    repository: str = "pyTMD",
+    branch: str = "main",
+    timeout: int | None = 360,
+    mode: oct = 0o775,
+):
+    """
+    Downloads an updated pyTMD model JSON database file from
+    the project GitHub repository
+
+    Parameters
+    ----------
+    username: str, default 'pyTMD'
+        GitHub username for project repository
+    repository: str, default 'pyTMD'
+        name of the GitHub repository
+    branch: str, default 'main'
+        branch of the GitHub repository for downloading files
+    timeout: int or None, default 360
+        timeout for the HTTP request in seconds
+    mode: oct, default 0o775
+        permissions mode of output file
+    """
+    # create logger for verbosity level
+    logger = pyTMD.utilities.build_logger(__name__, level=logging.INFO)
+    # path to model database
+    database = pyTMD.utilities.get_data_path(["data", "database.json"])
+    # check if the database file is writable
+    if os.access(database, os.R_OK) and not os.access(database, os.W_OK):
+        raise PermissionError(f"Database file is not writable: {database}")
+    # MD5 hash for comparing with remote
+    HASH = pyTMD.utilities.get_hash(database)
+    # try downloading from GitHub repository
+    HOST = pyTMD.utilities.get_github_url(
+        ["pyTMD", "data", database.name],
+        username=username,
+        repository=repository,
+        branch=branch,
+    )
+    # log message for failed download
+    msg = f"Unable to download {database.name} from {username}/{repository}"
+    try:
+        pyTMD.utilities.from_http(
+            HOST,
+            local=database,
+            hash=HASH,
+            timeout=timeout,
+            verbose=True,
+            mode=mode,
+        )
+    except pyTMD.utilities.urllib2.HTTPError as exc:
+        logger.info(msg)
+        logger.debug(exc.code)
+    except pyTMD.utilities.urllib2.URLError as exc:
+        logger.info(msg)
+        logger.debug(exc.reason)
+
+
+# PURPOSE: create argument parser
+def arguments():
+    parser = argparse.ArgumentParser(
+        description="""Downloads an updated pyTMD model JSON database
+            """,
+        fromfile_prefix_chars="@",
+    )
+    parser.convert_arg_line_to_args = pyTMD.utilities.convert_arg_line_to_args
+    # connection timeout
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        type=int,
+        default=360,
+        help="Timeout in seconds for blocking operations",
+    )
+    # permissions mode of the local directories and files (number in octal)
+    parser.add_argument(
+        "--mode",
+        "-M",
+        type=lambda x: int(x, base=8),
+        default=0o775,
+        help="Permissions mode of the files downloaded",
+    )
+    # return the parser
+    return parser
+
+
+# This is the main part of the program that calls the individual functions
+def main():
+    # Read the system arguments listed after the program
+    parser = arguments()
+    args, _ = parser.parse_known_args()
+
+    fetch_database(
+        timeout=args.timeout,
+        mode=args.mode,
+    )
+
+
+# run main program
+if __name__ == "__main__":
+    main()

--- a/pyTMD/utilities.py
+++ b/pyTMD/utilities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 utilities.py
-Written by Tyler Sutterley (05/2026)
+Written by Tyler Sutterley (06/2026)
 Download and management utilities for syncing time and auxiliary files
 
 PYTHON DEPENDENCIES:
@@ -11,6 +11,8 @@ PYTHON DEPENDENCIES:
         https://pypi.org/project/platformdirs/
 
 UPDATE HISTORY:
+    Updated 06/2026: can use an environment variable to set cache directory
+        this overrides the default platform-specific cache directory
     Updated 05/2026: add exists to URL class to check if URL is valid
         added function to get the github url of an item in the project repo
         added keyword arguments to allow for encrypted ftp connections
@@ -192,8 +194,19 @@ def get_cache_path(
     appname: str, default 'pytmd'
         Application name
     """
-    # get platform-specific cache directory
-    filepath = platformdirs.user_cache_path(appname=appname, ensure_exists=True)
+    # check for custom environment variable for cache directory
+    cache_dir = os.environ.get("PYTMD_CACHE_DIR")
+    if cache_dir:
+        # custom environment variable for cache directory
+        filepath = pathlib.Path(cache_dir).expanduser().absolute()
+        # ensure that the cache directory exists
+        filepath.mkdir(parents=True, exist_ok=True)
+    else:
+        # platform-specific cache directory
+        filepath = platformdirs.user_cache_path(
+            appname=appname, ensure_exists=True
+        )
+    # append relative path to cache directory
     if isinstance(relpath, list):
         # use *splat operator to extract from list
         filepath = filepath.joinpath(*relpath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = ["dask", "flake8", "gh", "oct2py", "pytest>=4.6", "pytest-cov", "pytest-xd
 "fetch_arcticdata.py" = "pyTMD.datasets.fetch_arcticdata:main" 
 "fetch_aviso_fes.py" = "pyTMD.datasets.fetch_aviso_fes:main" 
 "fetch_box_tpxo.py" = "pyTMD.datasets.fetch_box_tpxo:main"
+"fetch_database.py" = "pyTMD.datasets.fetch_database:main"
 "fetch_gsfc_got.py" = "pyTMD.datasets.fetch_gsfc_got:main" 
 "fetch_iers_opole.py" = "pyTMD.datasets.fetch_iers_opole:main"
 "fetch_jpl_ssd.py" = "pyTMD.datasets.fetch_jpl_ssd:main"


### PR DESCRIPTION
docs: add a configuration section to install
docs: improve `:ref:` usage throughout documentation
docs: reorder some sections
