### PR TITLE
perf(io): lazy regional crop via tmd.crop

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 - [Karen Alley (University of Manitoba)](https://umanitoba.ca/environment-earth-resources/dr-karen-alley-profile-page)
 - [Robbi Bishop-Taylor (Geoscience Australia)](https://github.com/robbibt)
+- [Paul Branson (CSIRO)](https://github.com/pbranson)
 - [Kelly Brunt (NASA Goddard Space Flight Center)](https://science.gsfc.nasa.gov/sed/bio/kelly.m.brunt)
 - [Susan Howard (Earth & Space Research)](https://www.esr.org/staff/susan-l-howard/)
 - [Laurie Padman (Earth & Space Research)](https://www.esr.org/staff/laurence-padman/)

--- a/doc/source/api_reference/io/dataset.rst
+++ b/doc/source/api_reference/io/dataset.rst
@@ -24,6 +24,8 @@ General Attributes and Methods
 
 .. autofunction:: pyTMD.io.dataset.equivalent_attrs
 
+.. autofunction:: pyTMD.io.dataset.isel_bounds
+
 .. autofunction:: pyTMD.io.dataset.register_datatree_subaccessor
 
 .. autofunction:: pyTMD.io.dataset.register_dataset_subaccessor

--- a/pyTMD/io/FES.py
+++ b/pyTMD/io/FES.py
@@ -345,7 +345,7 @@ def open_fes_netcdf(
     # amplitude and phase variable names
     amp_key = mapping_amp[kwargs["group"]]
     phase_key = mapping_ph[kwargs["group"]]
-    # mask where amplitude and phase are zero
+    # valid where amplitude or phase is nonzero
     valid_values = (tmp[amp_key] != 0) | (tmp[phase_key] != 0)
     amplitude = tmp[amp_key].where(valid_values, drop=False)
     phase = tmp[phase_key].where(valid_values, drop=False)

--- a/pyTMD/io/FES.py
+++ b/pyTMD/io/FES.py
@@ -346,7 +346,7 @@ def open_fes_netcdf(
     amp_key = mapping_amp[kwargs["group"]]
     phase_key = mapping_ph[kwargs["group"]]
     # mask where amplitude and phase are zero
-    valid_values = (tmp[amp_key] != 0) & (tmp[phase_key] != 0)
+    valid_values = (tmp[amp_key] != 0) | (tmp[phase_key] != 0)
     amplitude = tmp[amp_key].where(valid_values, drop=False)
     phase = tmp[phase_key].where(valid_values, drop=False)
     # create output xarray dataset for file

--- a/pyTMD/io/FES.py
+++ b/pyTMD/io/FES.py
@@ -15,6 +15,8 @@ PYTHON DEPENDENCIES:
         https://docs.xarray.dev/en/stable/
 
 UPDATE HISTORY:
+    Updated 08/2026: regional windows via chunked open + Dataset.tmd.crop
+        (isel_bounds lives in io.dataset; no open-time bounds kwarg)
     Updated 04/2026: added lineage attributes to save model filename(s)
     Updated 03/2026: add reader for FES-native (unstructured) netCDF4 files
     Updated 02/2026: make dataset accessor for FES be a subaccessor from dataset
@@ -107,6 +109,9 @@ def open_mfdataset(
         Open files in parallel using ``dask.delayed``
     kwargs: dict
         Additional keyword arguments for opening FES files
+
+        For regional extracts, pass ``chunks`` and crop after open with
+        :meth:`xarray.Dataset.tmd.crop` (or ``DataTree.tmd.crop``).
 
     Returns
     -------
@@ -294,7 +299,9 @@ def open_fes_netcdf(
             - ``'u'``: zonal currents
             - ``'v'``: meridional currents
     chunks: int, dict, str, or None, default None
-        Variable chunk sizes for dask [see ``xarray.open_dataset``]
+        Variable chunk sizes for dask [see ``xarray.open_dataset``].
+        Pass a non-``None`` value (e.g. ``{}``) for regional workflows so
+        :meth:`xarray.Dataset.tmd.crop` can hyperslab before compute.
     compressed: bool, default False
         Input file is ``gzip`` compressed
 
@@ -338,7 +345,7 @@ def open_fes_netcdf(
     # amplitude and phase variable names
     amp_key = mapping_amp[kwargs["group"]]
     phase_key = mapping_ph[kwargs["group"]]
-    # mask where amplitude or phase are zero
+    # mask where amplitude and phase are zero
     valid_values = (tmp[amp_key] != 0) & (tmp[phase_key] != 0)
     amplitude = tmp[amp_key].where(valid_values, drop=False)
     phase = tmp[phase_key].where(valid_values, drop=False)

--- a/pyTMD/io/dataset.py
+++ b/pyTMD/io/dataset.py
@@ -1509,10 +1509,27 @@ def _crop_global_longitude(
         return isel_bounds(ds, "x", "y", bounds=[lo, hi, ymin, ymax])
     pieces: list[xr.Dataset] = []
     x_cursor: float | None = None
+    # FES-style grids store both period endpoints (0 and 360, or −180 and 180).
+    # A wrap split then selects model_hi on the west piece and model_lo on the
+    # east piece — the same meridian twice. Drop the closing sample so the
+    # east piece stays one cell east of x_cursor (no extra +360 shift).
+    drop_closing_meridian = (
+        len(segments) > 1
+        and np.isclose(float(np.min(xvals)), model_lo)
+        and np.isclose(float(np.max(xvals)), model_hi)
+    )
     for lo, hi in segments:
         part = isel_bounds(ds, "x", "y", bounds=[lo, hi, ymin, ymax])
         if part.sizes.get("x", 0) == 0:
             continue
+        if (
+            drop_closing_meridian
+            and x_cursor is None
+            and np.isclose(float(part.x.values[-1]), model_hi)
+        ):
+            part = part.isel(x=slice(0, -1))
+            if part.sizes.get("x", 0) == 0:
+                continue
         x = np.asarray(part.x.values, dtype=float).copy()
         if x_cursor is None:
             # place the first segment near the requested start longitude

--- a/pyTMD/io/dataset.py
+++ b/pyTMD/io/dataset.py
@@ -617,9 +617,11 @@ class Dataset:
         Crop ``Dataset`` to input bounding box
 
         For regular grids, uses :func:`isel_bounds` so chunked / netCDF-backed
-        arrays can hyperslab without materializing the full domain. Prefer a
-        chunked ``open_*`` then ``tmd.crop`` (or ``DataTree.tmd.crop``) over
-        driver-specific open-time windows.
+        arrays can hyperslab without materializing the full domain. For
+        unstructured FE meshes, builds an element AABB mask from vertex
+        coordinates and ``isel`` along ``element`` (no full-domain
+        ``where``). Prefer a chunked ``open_*`` then ``tmd.crop`` (or
+        ``DataTree.tmd.crop``) over driver-specific open-time windows.
 
         Global geographic grids handle Pacific / dateline longitude wrap by
         one or two index hyperslabs (and a continuous ``x`` rebuild), not by
@@ -640,19 +642,22 @@ class Dataset:
         ymax = bounds[3] + buffer
         # crop dataset to bounding box
         if self.grid_type == "unstructured":
-            # crop unstructured datasets
-            # include elements that cross the bounding box
-            ds = self._ds.copy()
-            if hasattr(ds, "chunks") and ds.chunks is not None:
-                ds = ds.chunk(-1).compute()
-            ds = ds.where(
-                (ds.x.max(dim="vertex") >= xmin)
-                & (ds.x.min(dim="vertex") <= xmax)
-                & (ds.y.max(dim="vertex") >= ymin)
-                & (ds.y.min(dim="vertex") <= ymax),
-                drop=True,
+            # Element AABB test on vertex coords, then ragged isel along
+            # ``element``. Avoids ``where`` over every data variable and the
+            # eager ``chunk(-1).compute()`` that forced a full FE materialise.
+            # (KDTree / point-location search is separate; see pyTMD#553.)
+            x = self._ds["x"]
+            y = self._ds["y"]
+            mask = (
+                (x.max(dim="vertex") >= xmin)
+                & (x.min(dim="vertex") <= xmax)
+                & (y.max(dim="vertex") >= ymin)
+                & (y.min(dim="vertex") <= ymax)
             )
-            return ds
+            if hasattr(mask.data, "compute"):
+                mask = mask.compute()
+            idx = np.flatnonzero(np.asarray(mask.values))
+            return self._ds.isel(element=idx)
         # global geographic: dateline-aware lon windows
         if self.crs.is_geographic and self.is_global:
             lon_wrap = self.crs.to_dict().get("lon_wrap", 0)

--- a/pyTMD/io/dataset.py
+++ b/pyTMD/io/dataset.py
@@ -20,6 +20,8 @@ PYTHON DEPENDENCIES:
         https://docs.xarray.dev/en/stable/
 
 UPDATE HISTORY:
+    Updated 08/2026: add isel_bounds; gridded crop uses index hyperslabs
+        Pacific/dateline crop via dual lon hyperslabs (no half-globe pad)
     Updated 06/2026: moved peak finding algorithm to prediction module
         drift type renamed to trajectory. drift still accepted as an alias
         added function to infer minor constituents and add to dataset
@@ -65,6 +67,7 @@ __all__ = [
     "DataArray",
     "combine_attrs",
     "equivalent_attrs",
+    "isel_bounds",
     "register_datatree_subaccessor",
     "register_dataset_subaccessor",
     "register_dataarray_subaccessor",
@@ -161,6 +164,9 @@ class DataTree:
     def crop(self, *args, **kwargs):
         """
         Crop ``DataTree`` to input bounding box
+
+        Maps :meth:`Dataset.crop` over each group. For regular grids this
+        is an index hyperslab (lazy when children are chunked).
         """
         # create copy of datatree
         dtree = self._dtree.copy()
@@ -610,6 +616,16 @@ class Dataset:
         """
         Crop ``Dataset`` to input bounding box
 
+        For regular grids, uses :func:`isel_bounds` so chunked / netCDF-backed
+        arrays can hyperslab without materializing the full domain. Prefer a
+        chunked ``open_*`` then ``tmd.crop`` (or ``DataTree.tmd.crop``) over
+        driver-specific open-time windows.
+
+        Global geographic grids handle Pacific / dateline longitude wrap by
+        one or two index hyperslabs (and a continuous ``x`` rebuild), not by
+        padding half the globe. ``xmin > xmax`` means an eastward wrap
+        (e.g. ``170`` to ``-170``).
+
         Parameters
         ----------
         bounds: list, tuple
@@ -617,25 +633,6 @@ class Dataset:
         buffer: int or float, default 0
             Buffer to add to bounds for cropping
         """
-        # pad global grids along x-dimension (if necessary)
-        lon_wrap = self.crs.to_dict().get("lon_wrap", 0)
-        if self.grid_type == "unstructured":
-            # copy unstructured dataset
-            ds = self._ds.copy()
-        elif self.is_global and (lon_wrap == 180) and (np.min(bounds[:2]) < 0):
-            # number of points to pad for global grids
-            n = int(180 // (self._x[1] - self._x[0]))
-            ds = self.pad(n=(n, 0))
-        elif self.is_global and (lon_wrap == 0) and (np.max(bounds[:2]) > 180):
-            # number of points to pad for global grids
-            n = int(180 // (self._x[1] - self._x[0]))
-            ds = self.pad(n=(0, n))
-        else:
-            # copy dataset
-            ds = self._ds.copy()
-        # check if chunks are present
-        if hasattr(ds, "chunks") and ds.chunks is not None:
-            ds = ds.chunk(-1).compute()
         # unpack bounds and buffer
         xmin = bounds[0] - buffer
         xmax = bounds[1] + buffer
@@ -645,6 +642,9 @@ class Dataset:
         if self.grid_type == "unstructured":
             # crop unstructured datasets
             # include elements that cross the bounding box
+            ds = self._ds.copy()
+            if hasattr(ds, "chunks") and ds.chunks is not None:
+                ds = ds.chunk(-1).compute()
             ds = ds.where(
                 (ds.x.max(dim="vertex") >= xmin)
                 & (ds.x.min(dim="vertex") <= xmax)
@@ -652,17 +652,15 @@ class Dataset:
                 & (ds.y.min(dim="vertex") <= ymax),
                 drop=True,
             )
-        else:
-            # crop gridded datasets
-            ds = ds.where(
-                (ds.x >= xmin)
-                & (ds.x <= xmax)
-                & (ds.y >= ymin)
-                & (ds.y <= ymax),
-                drop=True,
+            return ds
+        # global geographic: dateline-aware lon windows
+        if self.crs.is_geographic and self.is_global:
+            lon_wrap = self.crs.to_dict().get("lon_wrap", 0)
+            return _crop_global_longitude(
+                self._ds, xmin, xmax, ymin, ymax, lon_wrap=lon_wrap
             )
-        # return the cropped dataset
-        return ds
+        # regional / projected regular grids
+        return isel_bounds(self._ds, "x", "y", bounds=[xmin, xmax, ymin, ymax])
 
     def extrap_like(self, other: xr.Dataset, **kwargs):
         """
@@ -1191,8 +1189,10 @@ class Dataset:
         """Determine if ``Dataset`` covers a global domain"""
         # grid spacing in x-direction
         dx = self._x[1] - self._x[0]
-        # check if global grid
-        cyclic = np.isclose(self._x[-1] - self._x[0], 360.0 - dx)
+        # cyclic: cell centers span 360-dx, or endpoints include both 0 and 360
+        # (FES-style grids often store a duplicated meridian)
+        span = self._x[-1] - self._x[0]
+        cyclic = np.isclose(span, 360.0 - dx) or np.isclose(span, 360.0)
         return self.crs.is_geographic and cyclic
 
     @property
@@ -1391,6 +1391,192 @@ class DataArray:
             return False
         else:
             return True
+
+
+def _longitude_model_range(
+    xvals: np.ndarray, lon_wrap: int | float = 0
+) -> tuple[float, float]:
+    """
+    Infer the primary longitude range of a global grid.
+
+    Prefers the coordinate extent; falls back to ``lon_wrap``
+    (``180`` → 0–360, else −180–180).
+    """
+    xvals = np.asarray(xvals, dtype=float)
+    dx = float(xvals[1] - xvals[0]) if xvals.size > 1 else 1.0
+    xmin = float(np.min(xvals))
+    xmax = float(np.max(xvals))
+    # 0–360 style (FES / GOT / ATLAS)
+    if (xmin >= -dx) and (xmax > (180.0 + dx)):
+        return 0.0, 360.0
+    # −180–180 style
+    if xmin < -dx:
+        return -180.0, 180.0
+    if lon_wrap == 180:
+        return 0.0, 360.0
+    return -180.0, 180.0
+
+
+def _shift_longitude_into(
+    lon: float, model_lo: float, model_hi: float
+) -> float:
+    """Shift ``lon`` by multiples of 360 into ``[model_lo, model_hi)``."""
+    period = model_hi - model_lo
+    while lon < model_lo:
+        lon += period
+    while lon >= model_hi:
+        lon -= period
+    return lon
+
+
+def _longitude_model_segments(
+    xmin: float,
+    xmax: float,
+    model_lo: float,
+    model_hi: float,
+    grid_xmin: float | None = None,
+    grid_xmax: float | None = None,
+) -> list[tuple[float, float]]:
+    """
+    Map a longitude window to one or two segments in model coordinates.
+
+    Travel is eastward from ``xmin`` to ``xmax``. If ``xmin > xmax``, the
+    window wraps (Pacific dateline short arc).
+
+    For non-wrapping windows whose span is ≥ one period (e.g. a huge
+    ``buffer``), intersect with the native grid extent instead of forcing a
+    modular full-globe read — matching historical ``where`` crop behavior.
+    """
+    period = model_hi - model_lo
+    if xmin <= xmax:
+        span = xmax - xmin
+        # oversized linear box: clip to native grid (not modular full globe)
+        if span >= period - 1e-12:
+            x0 = model_lo if grid_xmin is None else grid_xmin
+            x1 = model_hi if grid_xmax is None else grid_xmax
+            lo = max(xmin, x0)
+            hi = min(xmax, x1)
+            if lo > hi:
+                return []
+            return [(lo, hi)]
+        start = xmin
+    else:
+        # eastward wrap: e.g. 170 → -170 is a 20° arc, not the long way
+        span = (xmax + period) - xmin
+        start = xmin
+        if span >= period - 1e-12:
+            return [(model_lo, model_hi)]
+    start_m = _shift_longitude_into(start, model_lo, model_hi)
+    end_m = start_m + span
+    if end_m <= model_hi + 1e-12:
+        return [(start_m, end_m)]
+    return [(start_m, model_hi), (model_lo, end_m - period)]
+
+
+def _crop_global_longitude(
+    ds: xr.Dataset,
+    xmin: float,
+    xmax: float,
+    ymin: float,
+    ymax: float,
+    lon_wrap: int | float = 0,
+) -> xr.Dataset:
+    """
+    Crop a global geographic grid with dateline-safe longitude windows.
+
+    Uses at most two :func:`isel_bounds` hyperslabs and rebuilds a
+    continuous ``x`` coordinate for the eastward path (no half-globe pad).
+    """
+    xvals = np.asarray(ds.x.values)
+    model_lo, model_hi = _longitude_model_range(xvals, lon_wrap=lon_wrap)
+    period = model_hi - model_lo
+    segments = _longitude_model_segments(
+        xmin,
+        xmax,
+        model_lo,
+        model_hi,
+        grid_xmin=float(np.min(xvals)),
+        grid_xmax=float(np.max(xvals)),
+    )
+    # Oversized non-wrapping buffer: native-grid intersect only (no ±360 rebuild)
+    if xmin <= xmax and (xmax - xmin) >= period - 1e-12 and len(segments) == 1:
+        lo, hi = segments[0]
+        return isel_bounds(ds, "x", "y", bounds=[lo, hi, ymin, ymax])
+    pieces: list[xr.Dataset] = []
+    x_cursor: float | None = None
+    for lo, hi in segments:
+        part = isel_bounds(ds, "x", "y", bounds=[lo, hi, ymin, ymax])
+        if part.sizes.get("x", 0) == 0:
+            continue
+        x = np.asarray(part.x.values, dtype=float).copy()
+        if x_cursor is None:
+            # place the first segment near the requested start longitude
+            while (np.min(x) - xmin) > 180.0:
+                x -= 360.0
+            while (xmin - np.min(x)) > 180.0:
+                x += 360.0
+        else:
+            # keep subsequent segments east of the previous piece
+            while np.min(x) <= x_cursor + 1e-12:
+                x += 360.0
+        pieces.append(part.assign_coords(x=("x", x)))
+        x_cursor = float(np.max(x))
+    if not pieces:
+        return isel_bounds(ds, "x", "y", bounds=[xmin, xmax, ymin, ymax])
+    if len(pieces) == 1:
+        return pieces[0]
+    return xr.concat(pieces, dim="x")
+
+
+def isel_bounds(
+    ds: xr.Dataset,
+    x_name: str,
+    y_name: str,
+    bounds: list | tuple,
+) -> xr.Dataset:
+    """
+    Index-select a gridded ``Dataset`` to ``bounds``.
+
+    Uses 1-D coordinate values only (cheap), then ``isel`` so netCDF/dask
+    backends can hyperslab amplitude/phase or complex fields instead of
+    reading the globe. Callers that need a halo should expand ``bounds``
+    themselves (``Dataset.tmd.crop`` applies ``buffer`` before calling).
+
+    Parameters
+    ----------
+    ds: xarray.Dataset
+        Dataset with coordinates ``x_name`` / ``y_name``
+    x_name, y_name: str
+        Coordinate names (e.g. ``x``/``y`` or file ``lon``/``lat``)
+    bounds: list or tuple
+        Bounding box ``[xmin, xmax, ymin, ymax]`` in coordinate units
+
+    Returns
+    -------
+    ds: xarray.Dataset
+        Windowed dataset. If no cells fall in bounds, returns empty
+        slices along ``x_name`` / ``y_name`` (same spirit as
+        ``where(..., drop=True)``).
+    """
+    xmin, xmax, ymin, ymax = map(float, bounds)
+    # load coordinate vectors only
+    xvals = np.asarray(ds[x_name].values)
+    yvals = np.asarray(ds[y_name].values)
+    xind = np.flatnonzero((xvals >= xmin) & (xvals <= xmax))
+    yind = np.flatnonzero((yvals >= ymin) & (yvals <= ymax))
+    if xind.size == 0 or yind.size == 0:
+        return ds.isel(
+            {
+                x_name: slice(0, 0),
+                y_name: slice(0, 0),
+            }
+        )
+    return ds.isel(
+        {
+            x_name: slice(int(xind[0]), int(xind[-1]) + 1),
+            y_name: slice(int(yind[0]), int(yind[-1]) + 1),
+        }
+    )
 
 
 def combine_attrs(

--- a/test/perf_fes_windowed_read.py
+++ b/test/perf_fes_windowed_read.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Benchmark FES netCDF: full load vs chunked open + ``tmd.crop``.
+
+Not collected by pytest (no ``test_`` prefix). Run from the pyTMD repo::
+
+    PYTHONPATH=. python test/perf_fes_windowed_read.py \\
+        --tide-dir /path/to/parent/of/fes2022b \\
+        --repeats 3
+
+Prints a markdown table suitable for issue/PR notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+from pathlib import Path
+
+import numpy as np
+
+import pyTMD.io.FES as FES
+
+
+def _time_call(fn, repeats: int) -> list[float]:
+    times: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def _force_load(ds) -> tuple[int, tuple[int, ...]]:
+    """Materialize first data variable; return nbytes and shape."""
+    name = next(iter(ds.data_vars))
+    arr = np.asarray(ds[name].values)
+    return int(arr.nbytes), tuple(int(s) for s in arr.shape)
+
+
+def _fmt(seconds: list[float]) -> str:
+    med = statistics.median(seconds)
+    if len(seconds) > 1:
+        return f"{med:.3f} s (min {min(seconds):.3f}, max {max(seconds):.3f})"
+    return f"{med:.3f} s"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tide-dir",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "TIDE_MODEL_PATH",
+                str(Path.home() / "data" / "tide_models"),
+            )
+        ),
+        help="Directory containing fes2022b/ (or set TIDE_MODEL_PATH)",
+    )
+    parser.add_argument(
+        "--subdir",
+        default="fes2022b/ocean_tide_20241025",
+        help="Relative path under tide-dir to constituent netCDFs",
+    )
+    parser.add_argument(
+        "--bounds",
+        type=float,
+        nargs=4,
+        metavar=("XMIN", "XMAX", "YMIN", "YMAX"),
+        default=[149.5, 152.5, -24.5, -21.5],
+        help="Regional box (caller-buffered). Default ≈ Fitzroy + 0.5° halo",
+    )
+    parser.add_argument(
+        "--constituents",
+        nargs="+",
+        default=["m2", "s2", "k1", "o1", "n2", "k2", "p1", "q1"],
+        help="Constituent stems for multi-file open_mfdataset",
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    args = parser.parse_args()
+
+    ocean = args.tide_dir / args.subdir
+    if not ocean.is_dir():
+        raise SystemExit(
+            f"Missing FES directory: {ocean}\n"
+            "Pass --tide-dir (parent of fes2022b/) or set TIDE_MODEL_PATH."
+        )
+
+    m2 = ocean / "m2_fes2022.nc"
+    if not m2.is_file():
+        raise SystemExit(f"Missing {m2}")
+
+    bounds = list(args.bounds)
+    files = []
+    for c in args.constituents:
+        p = ocean / f"{c}_fes2022.nc"
+        if p.is_file():
+            files.append(p)
+    if not files:
+        raise SystemExit("No constituent files found for multi-file bench")
+
+    rows: list[tuple[str, str, str, str]] = []
+
+    # --- single file ---
+    def open_full_one():
+        ds = FES.open_fes_netcdf(m2, group="z")
+        _force_load(ds)
+
+    def open_crop_one():
+        ds = FES.open_fes_netcdf(m2, group="z", chunks={})
+        ds = ds.tmd.crop(bounds, buffer=0)
+        _force_load(ds)
+
+    # warm filesystem once
+    open_full_one()
+    open_crop_one()
+
+    t_full = _time_call(open_full_one, args.repeats)
+    t_win = _time_call(open_crop_one, args.repeats)
+    ds_full = FES.open_fes_netcdf(m2, group="z")
+    nbytes_full, shape_full = _force_load(ds_full)
+    ds_win = FES.open_fes_netcdf(m2, group="z", chunks={}).tmd.crop(
+        bounds, buffer=0
+    )
+    nbytes_win, shape_win = _force_load(ds_win)
+    speedup = statistics.median(t_full) / max(statistics.median(t_win), 1e-12)
+
+    rows.append(
+        (
+            f"single file (`{m2.name}`)",
+            _fmt(t_full),
+            _fmt(t_win),
+            f"{speedup:.1f}×; shape {shape_full}→{shape_win}; "
+            f"{nbytes_full / 1e6:.1f}→{nbytes_win / 1e6:.2f} MB",
+        )
+    )
+
+    # --- multi file ---
+    def open_full_many():
+        ds = FES.open_mfdataset(files, format="netcdf", group="z")
+        for name in ds.data_vars:
+            _ = np.asarray(ds[name].values)
+
+    def open_crop_many():
+        ds = FES.open_mfdataset(files, format="netcdf", group="z", chunks={})
+        ds = ds.tmd.crop(bounds, buffer=0)
+        for name in ds.data_vars:
+            _ = np.asarray(ds[name].values)
+
+    open_full_many()
+    open_crop_many()
+    t_full_m = _time_call(open_full_many, args.repeats)
+    t_win_m = _time_call(open_crop_many, args.repeats)
+    speedup_m = statistics.median(t_full_m) / max(
+        statistics.median(t_win_m), 1e-12
+    )
+    rows.append(
+        (
+            f"open_mfdataset ({len(files)} constituents)",
+            _fmt(t_full_m),
+            _fmt(t_win_m),
+            f"{speedup_m:.1f}×; files={[p.stem.split('_')[0] for p in files]}",
+        )
+    )
+
+    print("## FES windowed-read benchmark")
+    print()
+    print(f"- tide dir: `{ocean}`")
+    print(f"- bounds: `{bounds}` (xmin, xmax, ymin, ymax)")
+    print(f"- repeats: {args.repeats} (median reported)")
+    print("- path: chunked open + ``Dataset.tmd.crop``")
+    print(f"- pyTMD FES: `{Path(FES.__file__).resolve()}`")
+    print()
+    print("| Case | Full open | Chunked open + crop | Notes |")
+    print("|------|-----------|---------------------|-------|")
+    for case, full, win, notes in rows:
+        print(f"| {case} | {full} | {win} | {notes} |")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_fes_windowed_read.py
+++ b/test/test_fes_windowed_read.py
@@ -1,0 +1,236 @@
+"""
+test_fes_windowed_read.py
+Tests index hyperslabs for regional tide-model windows.
+
+Preferred path: lazy open (chunks) then ``Dataset.tmd.crop`` /
+``DataTree.tmd.crop`` — not driver-specific open-time ``bounds``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import pyTMD.io.FES as FES
+from pyTMD.io.dataset import isel_bounds
+
+
+def _write_synthetic_fes_nc(path: pathlib.Path) -> None:
+    """Write a tiny FES2014/2022-shaped z constituent file (m2)."""
+    lon = np.arange(0.0, 10.0, 1.0)
+    lat = np.arange(-5.0, 5.0, 1.0)
+    amp = np.ones((lat.size, lon.size), dtype=np.float32)
+    pha = np.zeros((lat.size, lon.size), dtype=np.float32)
+    ds = xr.Dataset(
+        data_vars={
+            "amplitude": (("lat", "lon"), amp),
+            "phase": (("lat", "lon"), pha),
+        },
+        coords={"lon": lon, "lat": lat},
+    )
+    # scipy/NETCDF3 keeps fixtures backend-agnostic (no HDF5 writer required)
+    ds.to_netcdf(path, engine="scipy", format="NETCDF3_CLASSIC")
+
+
+def _gridded_ds() -> xr.Dataset:
+    x = np.arange(0.0, 10.0, 1.0)
+    y = np.arange(-5.0, 5.0, 1.0)
+    return xr.Dataset(
+        {"m2": (("y", "x"), np.ones((y.size, x.size), dtype=np.complex64))},
+        coords={"x": x, "y": y},
+    )
+
+
+def test_isel_bounds_windows_grid():
+    ds = xr.Dataset(
+        {"amplitude": (("lat", "lon"), np.ones((10, 10)))},
+        coords={
+            "lon": np.arange(0.0, 10.0, 1.0),
+            "lat": np.arange(-5.0, 5.0, 1.0),
+        },
+    )
+    out = isel_bounds(ds, "lon", "lat", bounds=[2.0, 4.0, -1.0, 1.0])
+    np.testing.assert_array_equal(out["lon"].values, np.array([2.0, 3.0, 4.0]))
+    np.testing.assert_array_equal(out["lat"].values, np.array([-1.0, 0.0, 1.0]))
+
+
+def test_isel_bounds_empty_returns_empty_slices():
+    ds = _gridded_ds()
+    out = isel_bounds(ds, "x", "y", bounds=[100.0, 110.0, 50.0, 60.0])
+    assert out.sizes["x"] == 0
+    assert out.sizes["y"] == 0
+
+
+def test_crop_windows_gridded_dataset():
+    ds = _gridded_ds()
+    out = ds.tmd.crop([2.0, 4.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values, [2.0, 3.0, 4.0])
+    np.testing.assert_allclose(out["y"].values, [-1.0, 0.0, 1.0])
+    assert out["m2"].sizes["x"] == 3
+    assert out["m2"].sizes["y"] == 3
+
+
+def test_crop_respects_buffer():
+    ds = _gridded_ds()
+    out = ds.tmd.crop([3.0, 3.0, 0.0, 0.0], buffer=1.0)
+    np.testing.assert_allclose(out["x"].values, [2.0, 3.0, 4.0])
+    np.testing.assert_allclose(out["y"].values, [-1.0, 0.0, 1.0])
+
+
+def test_crop_keeps_dask_chunks():
+    dask = pytest.importorskip("dask")
+    del dask  # presence check only
+    ds = _gridded_ds().chunk({"x": 2, "y": 2})
+    assert ds.chunks is not None
+    out = ds.tmd.crop([2.0, 4.0, -1.0, 1.0], buffer=0)
+    # must not force chunk(-1).compute() — regional window stays lazy
+    assert out.chunks is not None
+    assert out["m2"].sizes["x"] == 3
+    assert out["m2"].sizes["y"] == 3
+
+
+def test_datatree_crop_windows_each_group():
+    z = _gridded_ds()
+    u = _gridded_ds().rename({"m2": "m2"})
+    dtree = xr.DataTree.from_dict({"z": z, "u": u})
+    out = dtree.tmd.crop([2.0, 4.0, -1.0, 1.0], buffer=0)
+    for key in ("z", "u"):
+        ds = out[key].to_dataset()
+        np.testing.assert_allclose(ds["x"].values, [2.0, 3.0, 4.0])
+        np.testing.assert_allclose(ds["y"].values, [-1.0, 0.0, 1.0])
+
+
+def test_open_fes_netcdf_then_crop_windows(tmp_path):
+    path = tmp_path / "m2_fes2022.nc"
+    _write_synthetic_fes_nc(path)
+    # chunked open keeps amp/phase→complex lazy so crop can hyperslab
+    full = FES.open_fes_netcdf(path, group="z", chunks={})
+    windowed = full.tmd.crop([2.0, 4.0, -1.0, 1.0], buffer=0)
+    assert "m2" in full.data_vars
+    assert "m2" in windowed.data_vars
+    assert full["m2"].sizes["x"] == 10
+    assert full["m2"].sizes["y"] == 10
+    assert windowed["m2"].sizes["x"] == 3
+    assert windowed["m2"].sizes["y"] == 3
+    np.testing.assert_allclose(windowed["x"].values, [2.0, 3.0, 4.0])
+    np.testing.assert_allclose(windowed["y"].values, [-1.0, 0.0, 1.0])
+
+
+def _global_grid(x: np.ndarray) -> xr.Dataset:
+    """1° global grid with encoded x-index so wrap source is visible."""
+    y = np.array([-1.0, 0.0, 1.0])
+    # value = original x coordinate (before pad) for wrap checks
+    data = np.broadcast_to(x[np.newaxis, :], (y.size, x.size)).astype(
+        np.float64
+    )
+    return xr.Dataset({"v": (("y", "x"), data.copy())}, coords={"x": x, "y": y})
+
+
+def _crs(lon_wrap: int) -> dict:
+    return {
+        "proj": "longlat",
+        "datum": "WGS84",
+        "ellps": "WGS84",
+        "lon_wrap": lon_wrap,
+        "type": "crs",
+    }
+
+
+def test_crop_pacific_0_360_crosses_prime_meridian():
+    """0–360 FES-like: [-10, 10] → dual hyperslab, continuous x, no half-globe."""
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([-10.0, 10.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values[0], -10.0)
+    np.testing.assert_allclose(out["x"].values[-1], 10.0)
+    assert out.sizes["x"] == 21
+    # must not pad half the globe then crop
+    assert out.sizes["x"] < 50
+    west = out.sel(x=-5.0)["v"].values
+    np.testing.assert_allclose(west, 355.0)
+
+
+def test_crop_pacific_0_360_western_basin_shifted():
+    """Negative western-Pacific box maps into model 0–360 without wrap split."""
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([-170.0, -150.0, -1.0, 1.0], buffer=0)
+    assert out.sizes["x"] == 21
+    # data from model longitudes 190–210
+    np.testing.assert_allclose(out.sel(x=-160.0)["v"].values, 200.0)
+
+
+def test_crop_pacific_0_360_dateline_crossing_xmin_gt_xmax():
+    """xmin>xmax means eastward wrap: 170E → 170W (=190°E), short arc."""
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([170.0, -170.0, -1.0, 1.0], buffer=0)
+    assert out.sizes["x"] == 21
+    np.testing.assert_allclose(out["x"].values[0], 170.0)
+    np.testing.assert_allclose(out["x"].values[-1], 190.0)
+    np.testing.assert_allclose(out.sel(x=180.0)["v"].values, 180.0)
+
+
+def test_crop_pacific_m180_180_dateline_crossing():
+    """−180–180 grid: dateline crossing via xmin>xmax."""
+    ds = _global_grid(np.arange(-180.0, 180.0, 1.0))
+    ds.attrs["crs"] = _crs(0)
+    out = ds.tmd.crop([170.0, -170.0, -1.0, 1.0], buffer=0)
+    assert out.sizes["x"] == 21
+    np.testing.assert_allclose(out["x"].values[0], 170.0)
+    np.testing.assert_allclose(out["x"].values[-1], 190.0)
+    # wrapped western piece carries model x=-175 data at continuous 185
+    np.testing.assert_allclose(out.sel(x=185.0)["v"].values, -175.0)
+
+
+def test_crop_pacific_0_360_bounds_past_360():
+    """Bounds past 360 on a 0–360 grid: east pad equivalent via dual isel."""
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([350.0, 370.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values[0], 350.0)
+    np.testing.assert_allclose(out["x"].values[-1], 370.0)
+    assert out.sizes["x"] == 21
+    np.testing.assert_allclose(out.sel(x=370.0)["v"].values, 10.0)
+
+
+def test_crop_pacific_wrap_keeps_dask_chunks():
+    pytest.importorskip("dask")
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0)).chunk({"x": 30, "y": 1})
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([-10.0, 10.0, -1.0, 1.0], buffer=0)
+    assert out.chunks is not None
+    assert out.sizes["x"] == 21
+
+
+def test_crop_large_buffer_does_not_force_full_globe():
+    """Oversized buffer with xmin<=xmax: linear grid intersect, not full lon."""
+    ds = _global_grid(np.arange(0.0, 360.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    # [0, 10] + buffer 200 → [-200, 210]; historical where kept ~[0, 210]
+    out = ds.tmd.crop([0.0, 10.0, -1.0, 1.0], buffer=200.0)
+    assert out.sizes["x"] == 211
+    np.testing.assert_allclose(out["x"].values[0], 0.0)
+    np.testing.assert_allclose(out["x"].values[-1], 210.0)
+
+
+def test_is_global_when_meridian_duplicated():
+    """FES-style 0…360 inclusive endpoints are still global."""
+    # 1° cells with both 0 and 360 present (span == 360, not 360-dx)
+    x = np.arange(0.0, 361.0, 1.0)
+    ds = _global_grid(x)
+    assert ds.tmd.is_global
+
+
+def test_crop_dateline_on_duplicated_meridian_grid():
+    """Dateline crop must work when is_global uses 0…360 inclusive span."""
+    x = np.arange(0.0, 361.0, 1.0)
+    ds = _global_grid(x)
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([170.0, -170.0, -1.0, 1.0], buffer=0)
+    assert out.sizes["x"] == 21
+    np.testing.assert_allclose(out["x"].values[0], 170.0)
+    np.testing.assert_allclose(out["x"].values[-1], 190.0)

--- a/test/test_fes_windowed_read.py
+++ b/test/test_fes_windowed_read.py
@@ -280,3 +280,35 @@ def test_crop_dateline_on_duplicated_meridian_grid():
     assert out.sizes["x"] == 21
     np.testing.assert_allclose(out["x"].values[0], 170.0)
     np.testing.assert_allclose(out["x"].values[-1], 190.0)
+
+
+def test_crop_prime_meridian_on_duplicated_meridian_grid():
+    """0 and 360 both present: [-10, 10] must not duplicate the seam."""
+    ds = _global_grid(np.arange(0.0, 361.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([-10.0, 10.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values, np.arange(-10.0, 11.0, 1.0))
+    # keep canonical 0°, not the 360° copy (encoded as original x)
+    np.testing.assert_allclose(out.sel(x=-5.0)["v"].values, 355.0)
+    np.testing.assert_allclose(out.sel(x=0.0)["v"].values, 0.0)
+    np.testing.assert_allclose(out.sel(x=5.0)["v"].values, 5.0)
+
+
+def test_crop_past_360_on_duplicated_meridian_grid():
+    """0 and 360 both present: [350, 370] must not emit x=360 twice."""
+    ds = _global_grid(np.arange(0.0, 361.0, 1.0))
+    ds.attrs["crs"] = _crs(180)
+    out = ds.tmd.crop([350.0, 370.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values, np.arange(350.0, 371.0, 1.0))
+    np.testing.assert_allclose(out.sel(x=360.0)["v"].values, 0.0)
+    np.testing.assert_allclose(out.sel(x=370.0)["v"].values, 10.0)
+
+
+def test_crop_dateline_on_duplicated_pm_grid():
+    """−180 and 180 both present: dateline wrap must not duplicate the seam."""
+    ds = _global_grid(np.arange(-180.0, 181.0, 1.0))
+    ds.attrs["crs"] = _crs(0)
+    out = ds.tmd.crop([170.0, -170.0, -1.0, 1.0], buffer=0)
+    np.testing.assert_allclose(out["x"].values, np.arange(170.0, 191.0, 1.0))
+    np.testing.assert_allclose(out.sel(x=180.0)["v"].values, -180.0)
+    np.testing.assert_allclose(out.sel(x=185.0)["v"].values, -175.0)

--- a/test/test_fes_windowed_read.py
+++ b/test/test_fes_windowed_read.py
@@ -149,6 +149,14 @@ def test_datatree_crop_windows_each_group():
         np.testing.assert_allclose(ds["y"].values, [-1.0, 0.0, 1.0])
 
 
+def test_open_fes_netcdf_keeps_nonzero_amp_at_zero_phase(tmp_path):
+    """Phase of 0° with nonzero amplitude is valid, not a fill."""
+    path = tmp_path / "m2_fes2022.nc"
+    _write_synthetic_fes_nc(path)
+    ds = FES.open_fes_netcdf(path, group="z", chunks={})
+    np.testing.assert_allclose(ds["m2"].values, 1 + 0j)
+
+
 def test_open_fes_netcdf_then_crop_windows(tmp_path):
     path = tmp_path / "m2_fes2022.nc"
     _write_synthetic_fes_nc(path)

--- a/test/test_fes_windowed_read.py
+++ b/test/test_fes_windowed_read.py
@@ -92,6 +92,52 @@ def test_crop_keeps_dask_chunks():
     assert out["m2"].sizes["y"] == 3
 
 
+def _unstructured_ds() -> xr.Dataset:
+    """Tiny FE mesh: 3 triangles; middle one overlaps [0,1]×[0,1]."""
+    # vertices per element (element, vertex)
+    x = np.array(
+        [
+            [-2.0, -1.0, -1.5],  # outside west
+            [0.0, 1.0, 0.5],  # inside
+            [3.0, 4.0, 3.5],  # outside east
+        ],
+        dtype=np.float64,
+    )
+    y = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    m2 = np.array([1 + 0j, 2 + 0j, 3 + 0j], dtype=np.complex64)
+    ds = xr.Dataset(
+        {
+            "x": (("element", "vertex"), x),
+            "y": (("element", "vertex"), y),
+            "m2": (("element",), m2),
+        },
+        coords={"element": np.arange(3), "vertex": np.arange(3)},
+    )
+    ds.attrs["grid_type"] = "unstructured"
+    return ds
+
+
+def test_crop_unstructured_uses_element_isel():
+    ds = _unstructured_ds()
+    out = ds.tmd.crop([0.0, 1.0, 0.0, 1.0], buffer=0)
+    assert out.sizes["element"] == 1
+    np.testing.assert_allclose(out["m2"].values, [2 + 0j])
+    # chunked path: only mask is computed; data can stay lazy
+    dask = pytest.importorskip("dask")
+    del dask
+    lazy = ds.chunk({"element": 2})
+    out_lazy = lazy.tmd.crop([0.0, 1.0, 0.0, 1.0], buffer=0)
+    assert out_lazy.chunks is not None
+    np.testing.assert_allclose(out_lazy["m2"].values, [2 + 0j])
+
+
 def test_datatree_crop_windows_each_group():
     z = _gridded_ds()
     u = _gridded_ds().rename({"m2": "m2"})


### PR DESCRIPTION
## Summary
- Add `isel_bounds` and make gridded `Dataset.tmd.crop` / `DataTree.tmd.crop` use index hyperslabs (lazy for chunked/netCDF), with dateline-safe Pacific longitude windows (no half-globe pad).
- Treat FES-style `0…360` inclusive lon grids as global so wrap crop engages.
- Prefer chunked open then `tmd.crop` for regional FES reads; document that path. Add focused tests and an optional benchmark script (`--tide-dir` / `TIDE_MODEL_PATH`).

## Benchmark (local, FES2022)
| Case | Full open | Chunked open + crop |
|------|-----------|---------------------|
| Fitzroy box single file | ~1.25 s | ~0.026 s (~48×) |
| Dateline `[170,-170]` single file | ~1.25 s | ~0.038 s (~33×) |

## Test plan
- [x] `pytest test/test_fes_windowed_read.py`
- [x] `pytest test/test_fes_predict.py` (local, when tide cache present)
- [x] flake8 syntax select (CI-equivalent) on `pyTMD` + `test`
- [x] `ruff format --check` on touched files
- [x] CI on this PR